### PR TITLE
keep multiple newlines in card output

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ alexa.response = function() {
 
     // remove all SSML to keep the card clean
     clenseAttrs.forEach(function(idx) {
-      oCard[idx] = SSML.cleanse(oCard[idx]);
+      oCard[idx] = SSML.cleanse(oCard[idx], true);
     });
 
     this.response.response.card = oCard;

--- a/to-ssml.js
+++ b/to-ssml.js
@@ -29,11 +29,13 @@ var ssml = {
 
     return ssml_str.replace(/  +/, " ");
   },
-  cleanse: function(str) {
+  cleanse: function(str, multiNewline) {
     // <p> is left in place to support intended HTML output
-    return str.replace(/<\/?(speak|break|phoneme|audio|say-as|s\b|w\b)[^>]*>/gi, " ")
-      .replace(/\s*\n\s*/g, "\n")
-      .replace(/  +/g, " ")
+    var rval = str.replace(/<\/?(speak|break|phoneme|audio|say-as|s\b|w\b)[^>]*>/gi, " ");
+    if (!multiNewline) {
+      rval = rval.replace(/\s*\n\s*/g, "\n");
+    }
+    return rval.replace(/  +/g, " ")
       .replace(/ ([.,!?;:])/g, "$1")
       .trim();
   }


### PR DESCRIPTION
Cards can use multiple newlines for formatting, but https://github.com/matt-kruse/alexa-app/blob/master/index.js#L91 reduces multiple newlines to one.  

This change skips the newline compression when cleansing SSML for card output.

Here's a sample card formatted with newlines:

![multiline_card](https://cloud.githubusercontent.com/assets/1649528/18612548/0655b96e-7d12-11e6-80f1-16462f405750.png)
