### PR TITLE
Prevent updating session attributes directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#119](https://github.com/alexa-js/alexa-app/pull/119): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
 * Your contribution here.
-* [#118](https://github.com/matt-kruse/alexa-app/pull/118): [#117](https://github.com/matt-kruse/alexa-app/issues/117) Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
+* [#118](https://github.com/matt-kruse/alexa-app/pull/118), [#117](https://github.com/matt-kruse/alexa-app/issues/117): Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
 
 ### 2.4.0 (January 5, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#119](https://github.com/alexa-js/alexa-app/pull/119): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
 * Your contribution here.
+* [#118](https://github.com/matt-kruse/alexa-app/pull/118): [#117](https://github.com/matt-kruse/alexa-app/issues/117) Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
 
 ### 2.4.0 (January 5, 2017)
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ var session = request.getSession()
 // set a session variable
 // by defailt, Alexa only persists session variables to the next request
 // the alexa-app module makes session variables persist across multiple requests
+// Note that you *must* use `.set` or `.clear` to update
+// session properties. Updating properties of `attributeValue`
+// that are objects will not persist until `.set` is called
 session.set(String attributeName, String attributeValue)
 
 // return the value of a session variable

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,7 +24,7 @@ if (request.hasSession()) {
   session.isNew();
   // set a session variable
   session.set("foo", "bar");
-  // get a session variable
+  // get a session variable (copies objects)
   session.get("foo");
   // delete one session variable
   session.clear("foo");
@@ -35,11 +35,15 @@ if (request.hasSession()) {
   // get session details
   session.details;
   // get session attributes (object of variables)
+  // NOTE: Working directly with these circumvents the deep
+  // copy returned by `session.get`
   session.attributes;
 }
 ```
 
 You can easily use the session, but first you need to check if `request` has session: `Boolean request.hasSession()`. Otherwise the session properties will be empty and the session functions will throw "NO_SESSION" exception.
 
-See [#91](https://github.com/alexa-js/alexa-app/pull/91) for more information.
+When working with the session, `session.get` will return a deep copy of the value stored in the session. If this value is an object and you make direct changes to the object, you must call `session.set` again in order for the changes to propagate to the session.
+
+See [#91](https://github.com/matt-kruse/alexa-app/pull/91) and [#118](https://github.com/matt-kruse/alexa-app/pull/118) for more information.
 

--- a/index.js
+++ b/index.js
@@ -263,7 +263,6 @@ alexa.session = function(session) {
     this.sessionId = null;
   }
   this.getAttributes = function() {
-    // do some stuff with session data
     // Deep clone attributes so direct updates to objects are not set in the
     // session unless `.set` is called explicitly
     return JSON.parse(JSON.stringify(this.attributes));

--- a/index.js
+++ b/index.js
@@ -227,7 +227,9 @@ alexa.session = function(session) {
       return (true === session.new);
     };
     this.get = function(key) {
-      return this.attributes[key];
+      // getAttributes deep clones the attributes object, so updates to objects
+      // will not affect the session until `set` is called explicitly
+      return this.getAttributes()[key];
     };
     this.set = function(key, value) {
       this.attributes[key] = value;
@@ -262,7 +264,9 @@ alexa.session = function(session) {
   }
   this.getAttributes = function() {
     // do some stuff with session data
-    return this.attributes;
+    // Deep clone attributes so direct updates to objects are not set in the
+    // session unless `.set` is called explicitly
+    return JSON.parse(JSON.stringify(this.attributes));
   };
 };
 

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -77,6 +77,66 @@ describe("Alexa", function() {
             )
           ]);
         });
+
+        it("does not update session properties without explicit set", function() {
+          testApp.pre = function(req, res, type) {
+            var session = req.getSession();
+            session.set("foo", true);
+            session.set("bar", {qaz: "woah"});
+          };
+
+          testApp.intent("airportInfoIntent", {}, function(req, res) {
+            res.say("message").shouldEndSession(false);
+            var session = req.getSession();
+            var bar = session.get("bar");
+            bar.qaz = "not woah";
+            return true;
+          });
+
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return response.sessionAttributes;
+          });
+
+          return Promise.all([
+            expect(subject).to.eventually.become({
+              foo: true,
+              bar: {
+                qaz: "woah"
+              }
+            })
+          ]);
+        });
+
+        it("updates session properties with explicit set", function() {
+          testApp.pre = function(req, res, type) {
+            var session = req.getSession();
+            session.set("foo", true);
+            session.set("bar", {qaz: "woah"});
+          };
+
+          testApp.intent("airportInfoIntent", {}, function(req, res) {
+            res.say("message").shouldEndSession(false);
+            var session = req.getSession();
+            var bar = session.get("bar");
+            bar.qaz = "not woah";
+            session.set("bar", bar);
+            session.set("foo", false);
+            return true;
+          });
+
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return response.sessionAttributes;
+          });
+
+          return Promise.all([
+            expect(subject).to.eventually.become({
+              foo: false,
+              bar: {
+                qaz: "not woah"
+              }
+            })
+          ]);
+        });
       });
     });
 


### PR DESCRIPTION
This change prevents users from updating the session attributes on the session object directly when working with the `session.getAttributes` and `session.get` methods.

Fixes #117 