### PR TITLE
Force new when instantiating alexa.app, added test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### 2.4.1 (Next)
 
+* [#125](https://github.com/alexa-js/alexa-app/pull/125): Force new when instantiating alexa.app - [@OpenDog](https://github.com/OpenDog).
 * [#119](https://github.com/alexa-js/alexa-app/pull/119): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
-* Your contribution here.
 * [#118](https://github.com/matt-kruse/alexa-app/pull/118), [#117](https://github.com/matt-kruse/alexa-app/issues/117): Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
 
 ### 2.4.0 (January 5, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#125](https://github.com/alexa-js/alexa-app/pull/125): Force new when instantiating alexa.app - [@OpenDog](https://github.com/OpenDog).
 * [#119](https://github.com/alexa-js/alexa-app/pull/119): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
+* Your contribution here
 * [#118](https://github.com/matt-kruse/alexa-app/pull/118), [#117](https://github.com/matt-kruse/alexa-app/issues/117): Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
 
 ### 2.4.0 (January 5, 2017)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 var Promise = require("bluebird");
 var AlexaUtterances = require("alexa-utterances");
 var SSML = require("./to-ssml");
@@ -272,10 +274,8 @@ alexa.session = function(session) {
 alexa.apps = {};
 
 alexa.app = function(name, endpoint) {
-  "use strict"
-
   if (!(this instanceof alexa.app)) {
-      throw new Error("Function needs to be called with the new keyword");
+      throw new Error("Function must be called with the new keyword");
   }
 
   var self = this;

--- a/index.js
+++ b/index.js
@@ -272,6 +272,12 @@ alexa.session = function(session) {
 alexa.apps = {};
 
 alexa.app = function(name, endpoint) {
+  "use strict"
+
+  if (!(this instanceof alexa.app)) {
+      throw new Error("Function needs to be called with the new keyword");
+  }
+
   var self = this;
   this.name = name;
   this.messages = {

--- a/test/test_alexa_app_creation.js
+++ b/test/test_alexa_app_creation.js
@@ -7,24 +7,21 @@ var expect = chai.expect;
 chai.config.includeStack = true;
 
 describe("Alexa", function () {
-    var Alexa = require("../index");
+  var Alexa = require("../index");
 
-    describe("app", function () {
-        var testApp;
+  describe("app", function () {
+    describe("instantiate app", function () {
+      it("fails when alexa.app was called without the new keyword", function () {
+        var message;
+          try {
+            var testApp = Alexa.app("testApp");
+          } catch (e) {
+            message = e.message;
+          }
 
-        describe("instantiate app", function () {
-            it("fails when alexa.app was called without the new keyword", function () {
-                var message;
-
-                try {
-                    testApp = Alexa.app("testApp");
-                } catch (e) {
-                    message = e.message;
-                }
-
-                return expect(Promise.resolve(message))
-                    .to.eventually.equal('Function needs to be called with the new keyword');
-            });
-        });
+          return expect(Promise.resolve(message))
+            .to.eventually.equal("Function must be called with the new keyword");
+      });
     });
+  });
 });

--- a/test/test_alexa_app_creation.js
+++ b/test/test_alexa_app_creation.js
@@ -13,14 +13,15 @@ describe("Alexa", function () {
     describe("instantiate app", function () {
       it("fails when alexa.app was called without the new keyword", function () {
         var message;
-          try {
-            var testApp = Alexa.app("testApp");
-          } catch (e) {
-            message = e.message;
-          }
 
-          return expect(Promise.resolve(message))
-            .to.eventually.equal("Function must be called with the new keyword");
+        try {
+          var testApp = Alexa.app("testApp");
+        } catch (e) {
+          message = e.message;
+        }
+
+        return expect(Promise.resolve(message))
+          .to.eventually.equal("Function must be called with the new keyword");
       });
     });
   });

--- a/test/test_alexa_app_creation.js
+++ b/test/test_alexa_app_creation.js
@@ -1,0 +1,30 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+chai.config.includeStack = true;
+
+describe("Alexa", function () {
+    var Alexa = require("../index");
+
+    describe("app", function () {
+        var testApp;
+
+        describe("instantiate app", function () {
+            it("fails when alexa.app was called without the new keyword", function () {
+                var message;
+
+                try {
+                    testApp = Alexa.app("testApp");
+                } catch (e) {
+                    message = e.message;
+                }
+
+                return expect(Promise.resolve(message))
+                    .to.eventually.equal('Function needs to be called with the new keyword');
+            });
+        });
+    });
+});


### PR DESCRIPTION
I accidentally left out the "new" keyword when I created the app (alexa.app()) and all hell broke loose. The requests died in a recursive call and chewed up the stack. This simple change is one way to prevent this.