### PR TITLE
Support Promises/callbacks from request handlers (#71)

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -7,6 +7,10 @@ env:
 globals:
   require: false
   module: false
+  describe: true
+  context: true
+  beforeEach: true
+  it: true
 rules:
   semi: 2
   no-console: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#125](https://github.com/alexa-js/alexa-app/pull/125): Force new when instantiating alexa.app - [@OpenDog](https://github.com/OpenDog).
 * [#119](https://github.com/alexa-js/alexa-app/pull/119): Moved to the [alexa-js organization](https://github.com/alexa-js) - [@dblock](https://github.com/dblock).
 * [#118](https://github.com/matt-kruse/alexa-app/pull/118), [#117](https://github.com/matt-kruse/alexa-app/issues/117): Prevent updating session attributes directly - [@ajcrites](https://github.com/ajcrites).
+* [#133](https://github.com/matt-kruse/alexa-app/pull/133), [#71](https://github.com/matt-kruse/alexa-app/issues/71): Support asynchronous patterns in request handlers - [@ajcrites](https://github.com/ajcrites).
 * Your contribution here.
 
 ### 2.4.0 (January 5, 2017)

--- a/index.js
+++ b/index.js
@@ -417,8 +417,8 @@ alexa.app = function(name, endpoint) {
             var intent = request_json.request.intent.name;
             if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
               var intentResult = self.intents[intent]["function"](request, response, callbackHandler);
-              if (intentResult instanceof Promise) {
-                intentResult.asCallback(callbackHandler);
+              if (intentResult && intentResult.then) {
+                Promise.resolve(intentResult).asCallback(callbackHandler);
               }
               else if (false !== intentResult) {
                 callbackHandler();
@@ -429,8 +429,8 @@ alexa.app = function(name, endpoint) {
           } else if ("LaunchRequest" === requestType) {
             if (typeof self.launchFunc == "function") {
               var launchResult = self.launchFunc(request, response, callbackHandler);
-              if (launchResult instanceof Promise) {
-                launchResult.asCallback(callbackHandler);
+              if (launchResult && launchResult.then) {
+                Promise.resolve(launchResult).asCallback(callbackHandler);
               }
               else if (false !== launchResult) {
                 callbackHandler();
@@ -441,8 +441,8 @@ alexa.app = function(name, endpoint) {
           } else if ("SessionEndedRequest" === requestType) {
             if (typeof self.sessionEndedFunc == "function") {
               var sessionEndedResult = self.sessionEndedFunc(request, response, callbackHandler);
-              if (sessionEndedResult instanceof Promise) {
-                sessionEndedResult.asCallback(callbackHandler);
+              if (sessionEndedResult && sessionEndedResult.then) {
+                Promise.resolve(sessionEndedResult).asCallback(callbackHandler);
               }
               else if (false !== sessionEndedResult) {
                 callbackHandler();
@@ -453,8 +453,8 @@ alexa.app = function(name, endpoint) {
             var eventHandlerObject = self.audioPlayerEventHandlers[event];
             if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
               var eventHandlerResult = eventHandlerObject["function"](request, response, callbackHandler);
-              if (eventHandlerObject instanceof Promise) {
-                eventHandlerResult.asCallback(callbackHandler);
+              if (eventHandlerObject && eventHandlerObject.then) {
+                Promise.resolve(eventHandlerResult).asCallback(callbackHandler);
               }
               else if (false !== eventHandlerResult) {
                 callbackHandler();


### PR DESCRIPTION
For Issue #71 

This allows you to return a Promise from a request handler (launch, intent handler, session ending, or audio player events). When the promise resolves, the response is sent. If the promise is rejected, it is treated like an error (e.g. if an error were thrown from the handler).

I have written the code so that it also now supports callbacks in an asynchronous pattern:

    skill.intent("intentName", utterances, (req, res, cb) => {
      someAsync(cb);
      return false;
    });

Currently you can either return a Promise or `false` from the handler in order to be asynchronous, but calling the callback makes calling `res.send` unnecessary.

This is backwards compatible, but I would be in favor of a major version change that supports _only_ promises and just using:

    Promise.resolve(handlerResult).then(res.send).catch(handleError);

We can also remove the `return false` functionality and make either returning a Promise or calling the callback required in order to send the response (or just call `response.send()` explicitly). I can either do this now as part of this PR or we can move forward with this and remove backwards compatibility later.