### PR TITLE
refactoring the express() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,9 +556,9 @@ app.launch(function(request,response) {
 });
 
 // ALWAYS setup the alexa app and attach it to express before anything else.
-app.express(express_app, express.Router(), "/echo/");
+app.express(express_app, express.Router());
 
-// now POST calls to /echo in express will be handled by the app.request() function
+// now POST calls to /sample in express will be handled by the app.request() function
 // GET calls will not be handled
 
 // from here on, you can setup any other express routes or middlewares as normal

--- a/README.md
+++ b/README.md
@@ -623,7 +623,6 @@ All named apps can be found in the `alexa.apps` object, keyed by name. The value
 
 Generally, an alexa-app module can be used inside a stand-alone Node.js app, within an HTTPS server or within an AWS Lambda function. The library only cares about JSON in and JSON out. It is agnostic about the environment that is using it, but it provides some convenience methods to hook into common environments.
 
-If you don't use AWS Lambda and host an Alexa skill on your own webserver, you will need to validate that requests come from Alexa. This validation is *not* provided by this module. For more details on how to handle alexa request validation, look at [alexa-verifier](https://github.com/alexa-js/alexa-verifier) which provides the necessary code.
 
 ### Development
 

--- a/README.md
+++ b/README.md
@@ -555,15 +555,14 @@ app.launch(function(request,response) {
   response.say("Hello World");
 });
 
-// this call defines a post() and optionally a get() handler in express, mapped to the alexa-app
-// express_app: the express app instance to map to
-//        path: the path prefix to map to
-// enableDebug: when false, don't map a GET handler, default is true
-//              debugging GET requests call express' render() method using 'test'
-app.express(express_app, "/echo/", false);
+// ALWAYS setup the alexa app and attach it to express before anything else.
+app.express(express_app, express.Router(), "/echo/");
 
-// now POST calls to /echo/sample in express will be handled by the app.request() function
+// now POST calls to /echo in express will be handled by the app.request() function
 // GET calls will not be handled
+
+// from here on, you can setup any other express routes or middlewares as normal
+
 ```
 
 ## Customizing Default Error Messages

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ app.launch(function(request,response) {
 });
 
 // ALWAYS setup the alexa app and attach it to express before anything else.
-app.express(express_app, express.Router());
+app.express({ expressApp: express_app, router: express.Router() });
 
 // now POST calls to /sample in express will be handled by the app.request() function
 // GET calls will not be handled

--- a/example/express.js
+++ b/example/express.js
@@ -13,14 +13,14 @@ alexaApp.express({
   expressApp: app,
   router: express.Router(),
 
-  // checkCert verifies requests come from amazon alexa. Must be enabled for production.
-  // you can disable this if you're running a dev environment and want to POST things
-  // to test behavior. enabled by default.
+  // verifies requests come from amazon alexa. Must be enabled for production.
+  // You can disable this if you're running a dev environment and want to POST
+  // things to test behavior. enabled by default.
   checkCert: false,
 
-  // enableDebug sets up a GET route when set to true. This is handy for testing in 
+  // sets up a GET route when set to true. This is handy for testing in 
   // development, but not recommended for production. disabled by default
-  enableDebug: true
+  debug: true
 });
 
 

--- a/example/express.js
+++ b/example/express.js
@@ -17,9 +17,13 @@ var checkCert = false
 // enableDebug sets up a GET route when set to true. This is handy for testing in 
 // development, but not recommended for production. disabled by default
 var enableDebug = true
-alexaApp.express(app, express.Router(), "/echo/", checkCert, enableDebug);
 
-// here you can setup any other express routes or middlewares as normal
+alexaApp.express(app, express.Router(), checkCert, enableDebug);
+
+// now POST calls to /test in express will be handled by the app.request() function
+
+
+// from here on you can setup any other express routes or middlewares as normal
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.set("view engine", "ejs");
@@ -43,4 +47,4 @@ alexaApp.intent("nameIntent", {
 );
 
 app.listen(PORT);
-console.log("Listening on port " + PORT + ", try http://localhost:" + PORT + "/echo/test");
+console.log("Listening on port " + PORT + ", try http://localhost:" + PORT + "/test");

--- a/example/express.js
+++ b/example/express.js
@@ -9,16 +9,20 @@ var app = express();
 // ALWAYS setup the alexa app and attach it to express before anything else.
 var alexaApp = new alexa.app("test");
 
-// checkCert verifies requests come from amazon alexa. Must be enabled for production.
-// you can disable this if you're running a dev environment and want to POST things
-// to test behavior. enabled by default.
-var checkCert = false
+alexaApp.express({
+  expressApp: app,
+  router: express.Router(),
 
-// enableDebug sets up a GET route when set to true. This is handy for testing in 
-// development, but not recommended for production. disabled by default
-var enableDebug = true
+  // checkCert verifies requests come from amazon alexa. Must be enabled for production.
+  // you can disable this if you're running a dev environment and want to POST things
+  // to test behavior. enabled by default.
+  checkCert: false,
 
-alexaApp.express(app, express.Router(), checkCert, enableDebug);
+  // enableDebug sets up a GET route when set to true. This is handy for testing in 
+  // development, but not recommended for production. disabled by default
+  enableDebug: true
+});
+
 
 // now POST calls to /test in express will be handled by the app.request() function
 

--- a/example/express.js
+++ b/example/express.js
@@ -2,14 +2,29 @@ var express = require("express");
 var alexa = require("../index.js");
 var bodyParser = require("body-parser");
 
-var app = express();
-var PORT = process.env.port || 8080;
 
+var PORT = process.env.port || 8080;
+var app = express();
+
+// ALWAYS setup the alexa app and attach it to express before anything else.
+var alexaApp = new alexa.app("test");
+
+// checkCert verifies requests come from amazon alexa. Must be enabled for production.
+// you can disable this if you're running a dev environment and want to POST things
+// to test behavior. enabled by default.
+var checkCert = false
+
+// enableDebug sets up a GET route when set to true. This is handy for testing in 
+// development, but not recommended for production. disabled by default
+var enableDebug = true
+alexaApp.express(app, express.Router(), "/echo/", checkCert, enableDebug);
+
+// here you can setup any other express routes or middlewares as normal
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.set("view engine", "ejs");
 
-var alexaApp = new alexa.app("test");
+
 alexaApp.launch(function(request, response) {
   response.say("You launched the app!");
 });
@@ -26,8 +41,6 @@ alexaApp.intent("nameIntent", {
     response.say("Success!");
   }
 );
-
-alexaApp.express(app, "/echo/");
 
 app.listen(PORT);
 console.log("Listening on port " + PORT + ", try http://localhost:" + PORT + "/echo/test");

--- a/index.js
+++ b/index.js
@@ -554,23 +554,23 @@ alexa.app = function(name) {
   // @return ? TODO: not sure what this returns
   this.express = function(options) {
     if (!options.expressApp) {
-      throw new Error("You must specify an express instance to attach to.")
+      throw new Error("You must specify an express instance to attach to.");
     }
 
     if (!options.router) {
-      throw new Error("You must specify an express router to attach.")
+      throw new Error("You must specify an express router to attach.");
     }
 
     var defaults = {
       endpoint: self.name,
       checkCert: true,
       debug: false
-    }
+    };
 
-    options = Object.assign(defaults, options)
+    options = Object.assign(defaults, options);
 
     var endpoint = "/" + options.endpoint;
-    var router = options.router
+    var router = options.router;
 
     options.expressApp.use(endpoint, router);
 

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Promise = require("bluebird");
 var AlexaUtterances = require("alexa-utterances");
 var SSML = require("./to-ssml");
 var alexa = {};
-var defaults = require("lodash.defaults")
+var defaults = require("lodash.defaults");
 var verifierMiddleware = require("alexa-verifier-middleware");
 
 alexa.response = function(session) {
@@ -563,7 +563,7 @@ alexa.app = function(name) {
     }
 
     var defaultOptions = { endpoint: self.name, checkCert: true, debug: false };
-    
+
     options = defaults(options, defaultOptions);
 
     var endpoint = "/" + options.endpoint;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var Promise = require("bluebird");
 var AlexaUtterances = require("alexa-utterances");
 var SSML = require("./to-ssml");
 var alexa = {};
+var defaults = require("lodash.defaults")
 var verifierMiddleware = require("alexa-verifier-middleware");
 
 alexa.response = function(session) {
@@ -561,13 +562,9 @@ alexa.app = function(name) {
       throw new Error("You must specify an express router to attach.");
     }
 
-    var defaults = {
-      endpoint: self.name,
-      checkCert: true,
-      debug: false
-    };
-
-    options = Object.assign(defaults, options);
+    var defaultOptions = { endpoint: self.name, checkCert: true, debug: false };
+    
+    options = defaults(options, defaultOptions);
 
     var endpoint = "/" + options.endpoint;
     var router = options.router;

--- a/index.js
+++ b/index.js
@@ -549,7 +549,7 @@ alexa.app = function(name) {
   // @param router options.express router instance to attach to the express app
   // @param string options.endpoint the path to attach the router to (e.g., passing 'mine' attaches to '/mine')
   // @param bool options.checkCert when true, applies Alexa certificate checking (default true)
-  // @param bool options.enableDebug when true, sets up the route to handle GET requests (default false)
+  // @param bool options.debug when true, sets up the route to handle GET requests (default false)
   // @throws Error when router or expressApp options are not specified
   // @return ? TODO: not sure what this returns
   this.express = function(options) {
@@ -564,7 +564,7 @@ alexa.app = function(name) {
     var defaults = {
       endpoint: self.name,
       checkCert: true,
-      enableDebug: false
+      debug: false
     }
 
     options = Object.assign(defaults, options)
@@ -587,7 +587,7 @@ alexa.app = function(name) {
       });
     });
 
-    if (options.enableDebug) {
+    if (options.debug) {
       router.get("/", function(req, res) {
         res.render("test", {
           "json": self,

--- a/index.js
+++ b/index.js
@@ -565,7 +565,7 @@ alexa.app = function(name, endpoint) {
     }
 
     // attach the express router to the express app
-    express_app.use(endpoint, router);
+    express.use(endpoint, router);
 
     // install the alexa-verifier-middleware
     router.use(verifierMiddleware({ strictHeaderCheck: certCheck }));

--- a/index.js
+++ b/index.js
@@ -564,8 +564,10 @@ alexa.app = function(name, endpoint) {
       enableDebug = false;
     }
 
+    console.log('attaching to endpoint', endpoint, 'flags:', certCheck, enableDebug)
     // attach the express router to the express app
     express.use(endpoint, router);
+
 
     // install the alexa-verifier-middleware
     router.use(verifierMiddleware({ strictHeaderCheck: certCheck }));

--- a/index.js
+++ b/index.js
@@ -575,7 +575,7 @@ alexa.app = function(name) {
     options.expressApp.use(endpoint, router);
 
     if (options.checkCert) {
-      options.router.use(verifierMiddleware({ strictHeaderCheck: checkCert }));
+      options.router.use(verifierMiddleware({ strictHeaderCheck: true }));
     }
 
     // exposes POST /<endpoint> route

--- a/index.js
+++ b/index.js
@@ -549,12 +549,11 @@ alexa.app = function(name, endpoint) {
   //
   // @param object express the express app to attach to
   // @param router express router instance to attach to the express app
-  // @param string path the endpoint to attach the router (e.g., /alexa)
   // @param bool certCheck when true, applies alexa certificate checking (default true)
   // @param bool enableDebug when true, sets up the route to handle GET requests (default false)
   // @return ? TODO: not sure what this returns
-  this.express = function(express, router, path, certCheck, enableDebug) {
-    var endpoint = (path || "/") + (self.endpoint || self.name);
+  this.express = function(express, router, certCheck, enableDebug) {
+    var endpoint = "/" + ( self.endpoint || self.name);
 
     if (typeof certCheck === "undefined" || certCheck === null) {
       certCheck = true;
@@ -564,7 +563,7 @@ alexa.app = function(name, endpoint) {
       enableDebug = false;
     }
 
-    console.log('attaching to endpoint', endpoint, 'flags:', certCheck, enableDebug)
+    console.log('attaching to endpoint', endpoint)
     // attach the express router to the express app
     express.use(endpoint, router);
 

--- a/index.js
+++ b/index.js
@@ -563,7 +563,7 @@ alexa.app = function(name, endpoint) {
       enableDebug = false;
     }
 
-    console.log('attaching to endpoint', endpoint)
+    console.log('attaching to endpoint', endpoint);
     // attach the express router to the express app
     express.use(endpoint, router);
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "license": "MIT",
   "dependencies": {
     "alexa-utterances": "^0.2.0",
+    "alexa-verifier-middleware": "^0.1.9",
     "bluebird": "^2.10.2",
     "numbered": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "alexa-utterances": "^0.2.0",
     "alexa-verifier-middleware": "^0.1.9",
     "bluebird": "^2.10.2",
+    "lodash.defaults": "^4.2.0",
     "numbered": "^1.0.0"
   },
   "devDependencies": {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -39,7 +39,7 @@ describe("Alexa", function() {
 
     context("#express with default options", function() {
       beforeEach(function() {
-        testApp.express(app, express.Router(), false)
+        testApp.express({ expressApp: app, router: express.Router(), checkCert: false });
       });
 
       it("returns a response for a valid request", function() {
@@ -71,7 +71,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to true", function() {
       beforeEach(function() {
-        testApp.express(app, express.Router(), false, true)
+        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, enableDebug: true });
       });
 
       it("dumps debug schema", function() {
@@ -85,7 +85,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to false", function() {
       beforeEach(function() {
-        testApp.express(app, express.Router(), false, false)
+        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, enableDebug: false });
       });
 
       it("cannot dump debug schema", function() {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -37,6 +37,27 @@ describe("Alexa", function() {
       testServer.close();
     });
 
+    context("#express fails when missing required field", function() {
+      it("throws error on missing express app", function() {
+        try {
+          testApp.express({ router: express.Router() });
+        } catch (er) {
+          return expect(er.message).to.eq("You must specify an express instance to attach to.")
+        }
+      });
+
+      it("throws error on missing express router", function() {
+        try {
+          testApp.express({ expressApp: app });
+        } catch (er) {
+          return expect(er.message).to.eq("You must specify an express router to attach.")
+        }
+      });
+
+    });
+
+
+
     context("#express with default options", function() {
       beforeEach(function() {
         testApp.express({ expressApp: app, router: express.Router(), checkCert: false });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -39,7 +39,7 @@ describe("Alexa", function() {
 
     context("#express with default options", function() {
       beforeEach(function() {
-        testApp.express(app, '/')
+        testApp.express(app, express.Router())
       });
 
       it("returns a response for a valid request", function() {
@@ -73,7 +73,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to true", function() {
       beforeEach(function() {
-        testApp.express(app, '/', true)
+        testApp.express(app, , express.Router(), false, true)
       });
 
       it("dumps debug schema", function() {
@@ -87,7 +87,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to false", function() {
       beforeEach(function() {
-        testApp.express(app, '/', false)
+        testApp.express(app, express.Router(), false, false)
       });
 
       it("cannot dump debug schema", function() {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -62,12 +62,10 @@ describe("Alexa", function() {
           });
       });
 
-      it("dumps debug schema", function() {
+      it("does not dump debug schema", function() {
         return request(testServer)
           .get('/testApp')
-          .expect(200).then(function(response) {
-            expect(response.text).to.startWith('{"name":"testApp"')
-          });
+          .expect(404);
       });
     });
 

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -71,7 +71,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to true", function() {
       beforeEach(function() {
-        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, enableDebug: true });
+        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, debug: true });
       });
 
       it("dumps debug schema", function() {
@@ -85,7 +85,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to false", function() {
       beforeEach(function() {
-        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, enableDebug: false });
+        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, debug: false });
       });
 
       it("cannot dump debug schema", function() {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -39,7 +39,7 @@ describe("Alexa", function() {
 
     context("#express with default options", function() {
       beforeEach(function() {
-        testApp.express(app, express.Router())
+        testApp.express(app, express.Router(), false)
       });
 
       it("returns a response for a valid request", function() {
@@ -73,7 +73,7 @@ describe("Alexa", function() {
 
     context("#express with debug set to true", function() {
       beforeEach(function() {
-        testApp.express(app, , express.Router(), false, true)
+        testApp.express(app, express.Router(), false, true)
       });
 
       it("dumps debug schema", function() {


### PR DESCRIPTION
people are having a lot of difficulty getting their middlewares defined in the right order. Especially on express apps that serve other traffic besides alexa skills.

This PR modifies the format of the call, and simplifies the usage.

