### PR TITLE
Fix: examples.

### DIFF
--- a/example/express.js
+++ b/example/express.js
@@ -1,7 +1,6 @@
 var express = require("express");
-var alexa = require("../index.js");
+var alexa = require("alexa-app");
 var bodyParser = require("body-parser");
-
 
 var PORT = process.env.port || 8080;
 var app = express();
@@ -18,20 +17,17 @@ alexaApp.express({
   // things to test behavior. enabled by default.
   checkCert: false,
 
-  // sets up a GET route when set to true. This is handy for testing in 
+  // sets up a GET route when set to true. This is handy for testing in
   // development, but not recommended for production. disabled by default
   debug: true
 });
 
-
 // now POST calls to /test in express will be handled by the app.request() function
-
 
 // from here on you can setup any other express routes or middlewares as normal
 app.use(bodyParser.urlencoded({ extended: true }));
 app.use(bodyParser.json());
 app.set("view engine", "ejs");
-
 
 alexaApp.launch(function(request, response) {
   response.say("You launched the app!");

--- a/example/package.json
+++ b/example/package.json
@@ -6,7 +6,8 @@
   "dependencies": {
     "body-parser": "^1.13.1",
     "ejs": "^2.3.1",
-    "express": "^4.13.0"
+    "express": "^4.13.0",
+    "alexa-app": ".."
   },
   "author": "Matt Kruse <github@mattkruse.com> (http://mattkruse.com/)",
   "license": "MIT"

--- a/example/test.js
+++ b/example/test.js
@@ -1,4 +1,4 @@
-var alexa = require("../index.js");
+var alexa = require("alexa-app");
 var template = require("./template.js");
 
 var app = new alexa.app("test");


### PR DESCRIPTION
I am not sure what I am missing, but requiring `../index.js` in examples causes this:

```
module.js:338
    throw err;
          ^
Error: Cannot find module 'bluebird'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (/Users/dblock/source/alexa/alexa-app/alexa-js/index.js:3:15)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```

This happens even if you explicitly include bluebird in the examples package.json. I think the right way is to reference the alexa-app module from the parent folder via package.json.