### PR TITLE
Dump schema and utterances in debug mode and added preRequest and postRequest support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Changelog
 
 ### 2.4.1 (Next)
+
+* [#150](https://github.com/alexa-js/alexa-app/pull/150): Dump schema and utterances in debug mode - [@dblock](https://github.com/dblock).
 * [#141](https://github.com/alexa-js/alexa-app/pull/141): Fail the response on exception in case of AudioPlayer request - [@fremail](https://github.com/fremail).
 * [#139](https://github.com/alexa-js/alexa-app/pull/139): Compatibility with Node.js v0.12 - v7 - [@tejashah88](https://github.com/tejashah88).
 * [#125](https://github.com/alexa-js/alexa-app/pull/125): Force new when instantiating alexa.app - [@OpenDog](https://github.com/OpenDog).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 2.4.1 (Next)
 
+* [#150](https://github.com/alexa-js/alexa-app/pull/150): Added `preRequest` and `postRequest` to express integration - [@dblock](https://github.com/dblock).
 * [#150](https://github.com/alexa-js/alexa-app/pull/150): Dump schema and utterances in debug mode - [@dblock](https://github.com/dblock).
 * [#141](https://github.com/alexa-js/alexa-app/pull/141): Fail the response on exception in case of AudioPlayer request - [@fremail](https://github.com/fremail).
 * [#139](https://github.com/alexa-js/alexa-app/pull/139): Compatibility with Node.js v0.12 - v7 - [@tejashah88](https://github.com/tejashah88).

--- a/index.js
+++ b/index.js
@@ -29,7 +29,7 @@ alexa.response = function(session) {
     }
     return this;
   };
-  this.clear = function(/*str*/) {
+  this.clear = function( /*str*/ ) {
     this.response.response.outputSpeech = {
       "type": "SSML",
       "ssml": SSML.fromStr("")
@@ -51,7 +51,7 @@ alexa.response = function(session) {
     return this;
   };
   this.card = function(oCard) {
-    if (2 == arguments.length) {  //backwards compat
+    if (2 == arguments.length) { // backwards compat
       oCard = {
         type: "Simple",
         title: arguments[0],
@@ -70,7 +70,7 @@ alexa.response = function(session) {
       case 'Standard':
         requiredAttrs.push('text');
         clenseAttrs.push('text');
-        if (('image' in oCard) && ( !('smallImageUrl' in oCard['image']) && !('largeImageUrl' in oCard['image']) )) {
+        if (('image' in oCard) && (!('smallImageUrl' in oCard['image']) && !('largeImageUrl' in oCard['image']))) {
           console.error('If card.image is defined, must specify at least smallImageUrl or largeImageUrl');
           return this;
         }
@@ -136,14 +136,14 @@ alexa.response = function(session) {
     };
     return this.audioPlayerPlay(playBehavior, audioItem);
   };
-  this.audioPlayerStop = function () {
+  this.audioPlayerStop = function() {
     var audioPlayerDirective = {
       "type": "AudioPlayer.Stop"
     };
     self.response.response.directives.push(audioPlayerDirective);
     return this;
   };
-  this.audioPlayerClearQueue = function (clearBehavior) {
+  this.audioPlayerClearQueue = function(clearBehavior) {
     var audioPlayerDirective = {
       "type": "AudioPlayer.ClearQueue",
       "clearBehavior": clearBehavior || "CLEAR_ALL"
@@ -280,7 +280,7 @@ alexa.apps = {};
 
 alexa.app = function(name) {
   if (!(this instanceof alexa.app)) {
-      throw new Error("Function must be called with the new keyword");
+    throw new Error("Function must be called with the new keyword");
   }
 
   var self = this;
@@ -311,8 +311,8 @@ alexa.app = function(name) {
   this.error = null;
 
   // pre/post hooks to be run on every request
-  this.pre = function(/*request, response, type*/) {};
-  this.post = function(/*request, response, type*/) {};
+  this.pre = function( /*request, response, type*/ ) {};
+  this.post = function( /*request, response, type*/ ) {};
 
   // A mapping of keywords to arrays of possible values, for expansion of sample utterances
   this.dictionary = {};
@@ -351,7 +351,7 @@ alexa.app = function(name) {
       var response = new alexa.response(request.getSession());
 
       // Error handling when a request fails in any way
-      var handleError = function (e) {
+      var handleError = function(e) {
         if (typeof self.error == "function") {
           self.error(e, request, response);
         } else if (typeof e == "string" && self.messages[e]) {
@@ -376,7 +376,7 @@ alexa.app = function(name) {
       var callbackHandlerCalled = false;
       // Sends the request or handles an error if an error is passed in
       // to the callback.
-      var callbackHandler = function (e) {
+      var callbackHandler = function(e) {
         if (callbackHandlerCalled) {
           console.warn("Response has already been sent");
           return;
@@ -385,8 +385,7 @@ alexa.app = function(name) {
 
         if (e) {
           handleError(e);
-        }
-        else {
+        } else {
           response.send();
         }
       };
@@ -427,8 +426,7 @@ alexa.app = function(name) {
               var intentResult = self.intents[intent]["function"](request, response, callbackHandler);
               if (intentResult && intentResult.then) {
                 Promise.resolve(intentResult).asCallback(callbackHandler);
-              }
-              else if (false !== intentResult) {
+              } else if (false !== intentResult) {
                 callbackHandler();
               }
             } else {
@@ -439,8 +437,7 @@ alexa.app = function(name) {
               var launchResult = self.launchFunc(request, response, callbackHandler);
               if (launchResult && launchResult.then) {
                 Promise.resolve(launchResult).asCallback(callbackHandler);
-              }
-              else if (false !== launchResult) {
+              } else if (false !== launchResult) {
                 callbackHandler();
               }
             } else {
@@ -451,8 +448,7 @@ alexa.app = function(name) {
               var sessionEndedResult = self.sessionEndedFunc(request, response, callbackHandler);
               if (sessionEndedResult && sessionEndedResult.then) {
                 Promise.resolve(sessionEndedResult).asCallback(callbackHandler);
-              }
-              else if (false !== sessionEndedResult) {
+              } else if (false !== sessionEndedResult) {
                 callbackHandler();
               }
             }
@@ -463,8 +459,7 @@ alexa.app = function(name) {
               var eventHandlerResult = eventHandlerObject["function"](request, response, callbackHandler);
               if (eventHandlerObject && eventHandlerObject.then) {
                 Promise.resolve(eventHandlerResult).asCallback(callbackHandler);
-              }
-              else if (false !== eventHandlerResult) {
+              } else if (false !== eventHandlerResult) {
                 callbackHandler();
               }
             } else {
@@ -483,8 +478,9 @@ alexa.app = function(name) {
   // Extract the schema and generate a schema JSON object
   this.schema = function() {
     var schema = {
-      "intents": []
-    }, intentName, intent, key;
+        "intents": []
+      },
+      intentName, intent, key;
     for (intentName in self.intents) {
       intent = self.intents[intentName];
       var intentSchema = {
@@ -573,11 +569,17 @@ alexa.app = function(name) {
 
     if (options.debug) {
       options.router.get("/", function(req, res) {
-        res.render("test", {
-          "json": self,
-          "schema": self.schema(),
-          "utterances": self.utterances()
-        });
+        if (typeof req.query['schema'] != "undefined") {
+          res.set('Content-Type', 'text/plain').send(self.schema());
+        } else if (typeof req.query['utterances'] != "undefined") {
+          res.set('Content-Type', 'text/plain').send(self.utterances());
+        } else {
+          res.render("test", {
+            "app": self,
+            "schema": self.schema(),
+            "utterances": self.utterances()
+          });
+        }
       });
     }
 

--- a/index.js
+++ b/index.js
@@ -604,13 +604,14 @@ alexa.app = function(name) {
         .then(self.request)
         .then(function(app_response_json) {
           response_json = app_response_json;
-          return Promise.resolve(typeof options.postRequest == "function" ? options.postRequest(app_response_json, req, res) : app_response_json)
+          return Promise.resolve(typeof options.postRequest == "function" ? options.postRequest(app_response_json, req, res) : app_response_json);
         })
         .then(function(response_json_new) {
           response_json = response_json_new || response_json;
           res.json(response_json).send();
         })
-        .catch(function() {
+        .catch(function(err) {
+          console.error(err);
           res.status(500).send("Server Error");
         });
     });

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -36,9 +36,9 @@ describe("Alexa", function() {
       });
 
       it("generates the expected schema", function() {
-        var expected = JSON.stringify(mockHelper.load("expected_intent_schema.json"));
-        var subject = JSON.stringify(JSON.parse(testApp.schema()));
-        expect(subject).to.eq(expected);
+        var expected = mockHelper.load("expected_intent_schema.json");
+        var subject = JSON.parse(testApp.schema());
+        expect(subject).to.eql(expected);
       });
     });
   });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -173,5 +173,36 @@ describe("Alexa", function() {
           });
       });
     });
+
+    context("#express with checkCert=true", function() {
+      beforeEach(function() {
+        testApp.express({
+          expressApp: app,
+          router: express.Router(),
+          checkCert: true,
+          debug: false
+        });
+      });
+
+      it("requires a cert header", function() {
+        return request(testServer)
+          .post('/testApp')
+          .expect(401).then(function(res) {
+            expect(res.body.status).to.equal("failure");
+            expect(res.body.reason).to.equal("The signaturecertchainurl HTTP request header is invalid!");
+          });
+      });
+
+      it("checks cert header", function() {
+        return request(testServer)
+          .post('/testApp')
+          .set('signaturecertchainurl', 'dummy')
+          .set('signature', 'dummy')
+          .expect(401).then(function(res) {
+            expect(res.body.status).to.equal("failure");
+            expect(res.body.reason).to.equal("signature is not base64 encoded");
+          });
+      });
+    });
   });
 });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -119,7 +119,7 @@ describe("Alexa", function() {
           .get('/testApp?schema')
           .expect(200).then(function(response) {
             expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
-            expect(response.text).to.include('"intent": "myIntent"')
+            expect(response.text).to.eq(testApp.schema());
           });
       });
 
@@ -128,7 +128,7 @@ describe("Alexa", function() {
           .get('/testApp?utterances')
           .expect(200).then(function(response) {
             expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
-            expect(response.text).to.include('my name is bob')
+            expect(response.text).to.eq(testApp.utterances());
           });
       });
     });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -144,5 +144,34 @@ describe("Alexa", function() {
           .expect(404);
       });
     });
+
+    context("#express with pre and post functions", function() {
+      var fired = {};
+      var mockRequest = mockHelper.load("intent_request_airport_info.json");
+
+      beforeEach(function() {
+        testApp.express({
+          expressApp: app,
+          router: express.Router(),
+          checkCert: false,
+          preRequest: function(json, request, response) {
+            fired.preRequest = json;
+          },
+          postRequest: function(json, request, response) {
+            fired.postRequest = json;
+          }
+        });
+      });
+
+      it("invokes pre and post functions", function() {
+        return request(testServer)
+          .post('/testApp')
+          .send(mockRequest)
+          .expect(200).then(function() {
+            expect(fired.preRequest).to.eql(mockRequest);
+            expect(fired.postRequest.response.outputSpeech.type).to.equal("SSML");
+          });
+      });
+    });
   });
 });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -56,8 +56,6 @@ describe("Alexa", function() {
 
     });
 
-
-
     context("#express with default options", function() {
       beforeEach(function() {
         testApp.express({ expressApp: app, router: express.Router(), checkCert: false });
@@ -92,7 +90,20 @@ describe("Alexa", function() {
 
     context("#express with debug set to true", function() {
       beforeEach(function() {
-        testApp.express({ expressApp: app, router: express.Router(), checkCert: false, debug: true });
+        testApp.intent("myIntent", {
+          "slots": {
+            "NAME": "LITERAL",
+            "AGE": "NUMBER"
+          },
+          "utterances": ["my name is bob"]
+        });
+
+        testApp.express({
+          expressApp: app,
+          router: express.Router(),
+          checkCert: false,
+          debug: true
+        });
       });
 
       it("dumps debug schema", function() {
@@ -100,6 +111,24 @@ describe("Alexa", function() {
           .get('/testApp')
           .expect(200).then(function(response) {
             expect(response.text).to.startWith('{"name":"testApp"')
+          });
+      });
+
+      it("returns debug schema", function() {
+        return request(testServer)
+          .get('/testApp?schema')
+          .expect(200).then(function(response) {
+            expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+            expect(response.text).to.include('"intent": "myIntent"')
+          });
+      });
+
+      it("returns debug utterances", function() {
+        return request(testServer)
+          .get('/testApp?utterances')
+          .expect(200).then(function(response) {
+            expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+            expect(response.text).to.include('my name is bob')
           });
       });
     });

--- a/test/views/test.ejs
+++ b/test/views/test.ejs
@@ -1,4 +1,4 @@
-<%- JSON.stringify(json) %>
+<%- JSON.stringify(app) %>
 
 <%- JSON.stringify(schema) %>
 


### PR DESCRIPTION
https://github.com/alexa-js/alexa-app-server/pull/56 attempts to call the express function from alexa-app instead of rewriting it. It seems logical to move some of the alexa-app-server debug functionality and pre and post request filtering further down.