### PR TITLE
Adding deprecation notices to docs and code for `return false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 3.0.1 (Next)
 
 * [#162](https://github.com/alexa-js/alexa-app/issues/162): Fix: do not generate empty slots in schema - [@dblock](https://github.com/dblock).
+* [#134](https://github.com/alexa-js/alexa-app/pull/134): Adding deprecation notices for plan to use Promises for async functionality - [ajcrites](https://github.com/ajcrites).
 * Your contribution here.
 
 ### 3.0.0 (February 6, 2017)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,44 @@
 # Upgrading Alexa-app
 
+### Upgrading to >= 4.0.0
+
+#### Changes to Asynchronous Support
+
+Support for asynchronous `pre` and `post` as well as all handlers such as the intent and launch handlers is now done through promises. This allows `pre` and `post` to be asynchronous.
+
+You can no longer make these handlers asynchronous by using `return false`. A callback is no longer taken as an argument to these handlers. Instead if you want your handler to be asynchronous you may return a promise.
+
+`response.send` and `response.fail` now return promises. If you call either, you must return them in order to continue the promise chain for any asynchronous functionality. If you return a promise but do not explicitly call `response.send` it will be called automatically when the returned promise resolves. If you want to trigger a failure, `return response.fail(error)` and `throw error` have the same effect.
+
+Before:
+```javascript
+app.intent("tellme", (request, response) => {
+  http.get(url, rc => {
+    if (rc.statusText >= 400) {
+      response.fail();
+    } else {
+      response.send(rc.body);
+    }
+  });
+
+  return false;
+});
+```
+
+After:
+```javascript
+app.intent("tellme", (request, response) => {
+  // `getAsync` returns a Promise in this example
+  return http.getAsync(url).then(rc => {
+    if (rc.statusText >= 400) {
+      return response.fail();
+    } else {
+      return response.send(rc.body);
+    }
+  });
+});
+```
+
 ### Upgrading to >= 3.0.0
 
 #### Changes in Express integration interface

--- a/index.js
+++ b/index.js
@@ -429,7 +429,7 @@ alexa.app = function(name) {
               } else if (false !== intentResult) {
                 callbackHandler();
               } else {
-                console.warn("NOTE: using `return false` for async intent requests is deprecated and will not work after the next major version");
+                console.trace("NOTE: using `return false` for async intent requests is deprecated and will not work after the next major version");
               }
             } else {
               throw "NO_INTENT_FOUND";
@@ -442,7 +442,7 @@ alexa.app = function(name) {
               } else if (false !== launchResult) {
                 callbackHandler();
               } else {
-                console.warn("NOTE: using `return false` for async launch requests is deprecated and will not work after the next major version");
+                console.trace("NOTE: using `return false` for async launch requests is deprecated and will not work after the next major version");
               }
             } else {
               throw "NO_LAUNCH_FUNCTION";
@@ -455,7 +455,7 @@ alexa.app = function(name) {
               } else if (false !== sessionEndedResult) {
                 callbackHandler();
               } else {
-                console.warn("NOTE: using `return false` for async session ended requests is deprecated and will not work after the next major version");
+                console.trace("NOTE: using `return false` for async session ended requests is deprecated and will not work after the next major version");
               }
             } else {
               response.send();
@@ -470,7 +470,7 @@ alexa.app = function(name) {
               } else if (false !== eventHandlerResult) {
                 callbackHandler();
               } else {
-                console.warn("NOTE: using `return false` for async audio player requests is deprecated and will not work after the next major version");
+                console.trace("NOTE: using `return false` for async audio player requests is deprecated and will not work after the next major version");
               }
             } else {
               response.send();

--- a/index.js
+++ b/index.js
@@ -428,6 +428,8 @@ alexa.app = function(name) {
                 Promise.resolve(intentResult).asCallback(callbackHandler);
               } else if (false !== intentResult) {
                 callbackHandler();
+              } else {
+                console.warn("NOTE: using `return false` for async intent requests is deprecated and will not work after the next major version");
               }
             } else {
               throw "NO_INTENT_FOUND";
@@ -439,6 +441,8 @@ alexa.app = function(name) {
                 Promise.resolve(launchResult).asCallback(callbackHandler);
               } else if (false !== launchResult) {
                 callbackHandler();
+              } else {
+                console.warn("NOTE: using `return false` for async launch requests is deprecated and will not work after the next major version");
               }
             } else {
               throw "NO_LAUNCH_FUNCTION";
@@ -450,6 +454,8 @@ alexa.app = function(name) {
                 Promise.resolve(sessionEndedResult).asCallback(callbackHandler);
               } else if (false !== sessionEndedResult) {
                 callbackHandler();
+              } else {
+                console.warn("NOTE: using `return false` for async session ended requests is deprecated and will not work after the next major version");
               }
             } else {
               response.send();
@@ -463,6 +469,8 @@ alexa.app = function(name) {
                 Promise.resolve(eventHandlerResult).asCallback(callbackHandler);
               } else if (false !== eventHandlerResult) {
                 callbackHandler();
+              } else {
+                console.warn("NOTE: using `return false` for async audio player requests is deprecated and will not work after the next major version");
               }
             } else {
               response.send();


### PR DESCRIPTION
In the next major version, `return false` and callbacks for async functionality will be removed in favor of using promises.

This pull requests does updates to various places to make that clear for the current version.