### PR TITLE
Updating library for asynchronous support through promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 ## Changelog
 
 ### 4.0.0 (Next)
-* Your contributions here
+* [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises and removing `return false`/callback functionality - [@ajcrites](https://github.com/ajcrites).
+* [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).
+* Your contribution here.
 
 ### 3.2.0 (February 24, 2017)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,7 +8,7 @@ Support for asynchronous `pre` and `post` as well as all handlers such as the in
 
 You can no longer make these handlers asynchronous by using `return false`. A callback is no longer taken as an argument to these handlers. Instead if you want your handler to be asynchronous you may return a promise.
 
-`response.send` and `response.fail` now return promises. If you call either, you must return them in order to continue the promise chain for any asynchronous functionality. If you return a promise but do not explicitly call `response.send` it will be called automatically when the returned promise resolves. If you want to trigger a failure, `return response.fail(error)` and `throw error` have the same effect.
+`response.send` and `response.fail` now return promises. If you call either, you must return them in order to continue the promise chain for any asynchronous functionality. If you return a promise but do not explicitly call `response.send` it will be called automatically when the returned promise resolves. If you want to trigger a failure, `return response.fail(error)` and `throw error` have the same effect. If a promise returned from a handler is rejected it will be treated as if you had called explicit failure as well.
 
 Before:
 ```javascript

--- a/index.js
+++ b/index.js
@@ -434,7 +434,15 @@ alexa.app = function(name) {
     })
     .catch(function(e) {
       if (typeof self.error == "function") {
-        return self.error(e, request, response);
+        // Default behavior of any error handler is to send a response
+        return Promise.resolve(self.error(e, request, response)).then(function() {
+            if (!response.resolved) {
+                response.resolved = true;
+                return response.send();
+            }
+            // propagate successful response if it's already been resolved
+            return response.response;
+        });
       } else if (typeof e == "string" && self.messages[e]) {
         if (!request.isAudioPlayer()) {
           response.say(self.messages[e]);

--- a/index.js
+++ b/index.js
@@ -353,145 +353,95 @@ alexa.app = function(name) {
     self.sessionEndedFunc = func;
   };
   this.request = function(request_json) {
-    return new Promise(function(resolve, reject) {
-      var request = new alexa.request(request_json);
-      var response = new alexa.response(request.getSession());
+    var request = new alexa.request(request_json);
+    var response = new alexa.response(request.getSession());
+    var postExecuted = false;
+    var requestType = request.type();
+    var prePromise = Promise.resolve();
 
-      // error handling when a request fails in any way
-      var handleError = function(e) {
-        if (typeof self.error == "function") {
-          self.error(e, request, response);
-          if (!response.resolved) {
-              response.send();
-          }
-        } else if (typeof e == "string" && self.messages[e]) {
-          if (!request.isAudioPlayer()) {
-            response.say(self.messages[e]);
-            response.send(e);
-          } else {
-            response.fail(self.messages[e]);
-          }
-        }
-        if (!response.resolved) {
-          if (e.message) {
-            response.fail("Unhandled exception: " + e.message + ".", e);
-          } else if (typeof e == "string") {
-            response.fail("Unhandled exception: " + e + ".", e);
-          } else {
-            response.fail("Unhandled exception.", e);
-          }
-        }
-      };
-
-      // prevent callback handler (request resolution) from being called multiple times
-      var callbackHandlerCalled = false;
-      // sends the request or handles an error if an error is passed in to the callback
-      var callbackHandler = function(e) {
-        if (callbackHandlerCalled) {
-          console.warn("Response has already been sent");
-          return;
-        }
-        callbackHandlerCalled = true;
-
-        if (e) {
-          handleError(e);
-        } else {
-          response.send();
-        }
-      };
-
-      var postExecuted = false;
-      // attach Promise resolve/reject functions to the response object
-      response.send = function(exception) {
-        response.prepare();
-        if (typeof self.post == "function" && !postExecuted) {
-          postExecuted = true;
-          self.post(request, response, requestType, exception);
-        }
-        if (!response.resolved) {
-          response.resolved = true;
-          resolve(response.response);
-        }
-      };
-      response.fail = function(msg, exception) {
-        response.prepare();
-        if (typeof self.post == "function" && !postExecuted) {
-          postExecuted = true;
-          self.post(request, response, requestType, exception);
-        }
-        if (!response.resolved) {
-          response.resolved = true;
-          reject(msg);
-        }
-      };
-      try {
-        var requestType = request.type();
-        if (typeof self.pre == "function") {
-          self.pre(request, response, requestType);
-        }
-        if (!response.resolved) {
-          if ("IntentRequest" === requestType) {
-            var intent = request_json.request.intent.name;
-            if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
-              var intentResult = self.intents[intent]["function"](request, response, callbackHandler);
-              if (intentResult && intentResult.then) {
-                Promise.resolve(intentResult).asCallback(callbackHandler);
-              } else if (false !== intentResult) {
-                callbackHandler();
-              } else {
-                console.trace("NOTE: using `return false` for async intent requests is deprecated and will not work after the next major version");
-              }
-            } else {
-              throw "NO_INTENT_FOUND";
-            }
-          } else if ("LaunchRequest" === requestType) {
-            if (typeof self.launchFunc == "function") {
-              var launchResult = self.launchFunc(request, response, callbackHandler);
-              if (launchResult && launchResult.then) {
-                Promise.resolve(launchResult).asCallback(callbackHandler);
-              } else if (false !== launchResult) {
-                callbackHandler();
-              } else {
-                console.trace("NOTE: using `return false` for async launch requests is deprecated and will not work after the next major version");
-              }
-            } else {
-              throw "NO_LAUNCH_FUNCTION";
-            }
-          } else if ("SessionEndedRequest" === requestType) {
-            if (typeof self.sessionEndedFunc == "function") {
-              var sessionEndedResult = self.sessionEndedFunc(request, response, callbackHandler);
-              if (sessionEndedResult && sessionEndedResult.then) {
-                Promise.resolve(sessionEndedResult).asCallback(callbackHandler);
-              } else if (false !== sessionEndedResult) {
-                callbackHandler();
-              } else {
-                console.trace("NOTE: using `return false` for async session ended requests is deprecated and will not work after the next major version");
-              }
-            } else {
-              response.send();
-            }
-          } else if (request.isAudioPlayer()) {
-            var event = requestType.slice(12);
-            var eventHandlerObject = self.audioPlayerEventHandlers[event];
-            if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
-              var eventHandlerResult = eventHandlerObject["function"](request, response, callbackHandler);
-              if (eventHandlerObject && eventHandlerObject.then) {
-                Promise.resolve(eventHandlerResult).asCallback(callbackHandler);
-              } else if (false !== eventHandlerResult) {
-                callbackHandler();
-              } else {
-                console.trace("NOTE: using `return false` for async audio player requests is deprecated and will not work after the next major version");
-              }
-            } else {
-              response.send();
-            }
-          } else {
-            throw "INVALID_REQUEST_TYPE";
-          }
-        }
-      } catch (e) {
-        handleError(e);
+    // attach Promise resolve/reject functions to the response object
+    response.send = function(exception) {
+      response.prepare();
+      var postPromise = Promise.resolve();
+      if (typeof self.post == "function" && !postExecuted) {
+        postExecuted = true;
+        postPromise = Promise.resolve(self.post(request, response, requestType, exception));
       }
+      return postPromise.then(function() {
+        if (!response.resolved) {
+          response.resolved = true;
+          return response.response;
+        }
+      });
+    };
+    response.fail = function(msg, exception) {
+      response.prepare();
+      var postPromise = Promise.resolve();
+      if (typeof self.post == "function" && !postExecuted) {
+        postExecuted = true;
+        postPromise = Promise.resolve(self.post(request, response, requestType, exception));
+      }
+      return postPromise.then(function() {
+        if (!response.resolved) {
+          response.resolved = true;
+          throw msg;
+        }
+      });
+    };
+
+    if (typeof self.pre == "function") {
+      prePromise = Promise.resolve(self.pre(request, response, requestType));
+    }
+    return prePromise.then(function() {
+      if (!response.resolved) {
+        if ("IntentRequest" === requestType) {
+          var intent = request_json.request.intent.name;
+          if (typeof self.intents[intent] != "undefined" && typeof self.intents[intent]["function"] == "function") {
+            return Promise.resolve(self.intents[intent]["function"](request, response));
+          } else {
+            throw "NO_INTENT_FOUND";
+          }
+        } else if ("LaunchRequest" === requestType) {
+          if (typeof self.launchFunc == "function") {
+            return Promise.resolve(self.launchFunc(request, response));
+          } else {
+            throw "NO_LAUNCH_FUNCTION";
+          }
+        } else if ("SessionEndedRequest" === requestType && typeof self.sessionEndedFunc == "function") {
+          return Promise.resolve(self.sessionEndedFunc(request, response));
+        } else if (request.isAudioPlayer()) {
+          var event = requestType.slice(12);
+          var eventHandlerObject = self.audioPlayerEventHandlers[event];
+          if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
+            return Promise.resolve(eventHandlerObject["function"](request, response));
+          }
+        } else {
+          throw "INVALID_REQUEST_TYPE";
+        }
+      }
+    })
+    .then(response.send)
+    .catch(function(e) {
+      if (typeof self.error == "function") {
+        return self.error(e, request, response);
+      } else if (typeof e == "string" && self.messages[e]) {
+        if (!request.isAudioPlayer()) {
+          response.say(self.messages[e]);
+          return response.send(e);
+        } else {
+          return response.fail(self.messages[e]);
+        }
+      }
+      if (!response.resolved) {
+        if (e.message) {
+          return response.fail("Unhandled exception: " + e.message + ".", e);
+        } else if (typeof e == "string") {
+          return response.fail("Unhandled exception: " + e + ".", e);
+        } else {
+          return response.fail("Unhandled exception.", e);
+        }
+      }
+      throw e;
     });
   };
 

--- a/index.js
+++ b/index.js
@@ -429,7 +429,9 @@ alexa.app = function(name) {
         }
       }
     })
-    .then(response.send)
+    .then(function () {
+      return response.send();
+    })
     .catch(function(e) {
       if (typeof self.error == "function") {
         return self.error(e, request, response);

--- a/test/test_alexa_app_audioplayer.js
+++ b/test/test_alexa_app_audioplayer.js
@@ -6,6 +6,7 @@ var mockHelper = require("./helpers/mock_helper");
 chai.use(chaiAsPromised);
 var expect = chai.expect;
 chai.config.includeStack = true;
+var Promise = require("bluebird");
 
 
 describe("Alexa", function () {
@@ -217,11 +218,14 @@ describe("Alexa", function () {
             var playBehavior = "ENQUEUE";
 
             testApp.audioPlayer("PlaybackFinished", function(request, response) {
-              setTimeout(function() {
-                response.audioPlayerPlayStream(playBehavior, stream);
-                response.send();
-              }, 0);
-              return false;
+              return new Promise(function(resolve) {
+                setTimeout(function() {
+                  response.audioPlayerPlayStream(playBehavior, stream);
+                  resolve();
+                }, 0);
+              }).then(function() {
+                return response.send();
+              });
             });
 
             var subject = testApp.request(mockRequest).then(function(response) {

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -204,26 +204,6 @@ describe("Alexa", function() {
                 });
               });
 
-              it("responds with expected message for callback", function() {
-                var intentHandler = function(req, res, cb) {
-                  res.say(expectedMessage);
-                  cb();
-                  return false;
-                };
-
-                testApp.intent("airportInfoIntent", {}, intentHandler);
-
-                var subject = testApp.request(mockRequest);
-                subject = subject.then(function(response) {
-                  return response.response.outputSpeech;
-                });
-
-                return expect(subject).to.eventually.become({
-                  ssml: "<speak>" + expectedMessage + "</speak>",
-                  type: "SSML"
-                });
-              });
-
               it("responds with expected message for promise", function() {
                 var intentHandler = function(req, res) {
                   return Promise.resolve().then(function() {
@@ -282,8 +262,7 @@ describe("Alexa", function() {
                 it("fails ungracefully", function() {
                   testApp.intent("airportInfoIntent", {},
                     function(req, res) {
-                      res.fail("whoops");
-                      return true;
+                      return res.fail("whoops");
                     });
 
                   var subject = testApp.request(mockRequest);
@@ -292,13 +271,12 @@ describe("Alexa", function() {
 
                 it("can clear failure in post", function() {
                   testApp.post = function(req, res, type) {
-                    res.clear().say("An error occured!").send();
+                    return res.clear().say("An error occured!").send();
                   };
 
                   testApp.intent("airportInfoIntent", {},
                     function(req, res) {
-                      res.fail("whoops");
-                      return true;
+                      return res.fail("whoops");
                     });
 
                   var subject = testApp.request(mockRequest).then(function(response) {
@@ -317,19 +295,6 @@ describe("Alexa", function() {
                   testApp.intent("airportInfoIntent", {},
                     function(req, res) {
                       throw new Error("whoops");
-                    });
-
-                  var subject = testApp.request(mockRequest);
-                  return expect(subject).to.be.rejectedWith("Unhandled exception: whoops.");
-                });
-              });
-
-              context("when an error is passed to the callback", function() {
-                it("reports failure", function() {
-                  testApp.intent("airportInfoIntent", {},
-                    function(req, res, cb) {
-                      cb(new Error("whoops"));
-                      return false;
                     });
 
                   var subject = testApp.request(mockRequest);

--- a/test/test_alexa_app_launch_request.js
+++ b/test/test_alexa_app_launch_request.js
@@ -104,39 +104,6 @@ describe("Alexa", function() {
                 });
               });
 
-              it("responds with expected message for callback", function() {
-                testApp.launch(function(req, res, cb) {
-                  res.say(expectedMessage);
-
-                  cb();
-
-                  return false;
-                });
-
-                var subject = testApp.request(mockRequest).then(function(response) {
-                  return response.response.outputSpeech;
-                });
-
-                return expect(subject).to.eventually.become({
-                  ssml: "<speak>" + expectedMessage + "</speak>",
-                  type: "SSML"
-                });
-              });
-
-              it("handles error for callback", function() {
-                testApp.launch(function(req, res, cb) {
-                  res.say(expectedMessage);
-
-                  cb(new Error("callback failure"));
-
-                  return false;
-                });
-
-                var subject = testApp.request(mockRequest);
-
-                return expect(subject).to.be.rejectedWith("callback failure");
-              });
-
               it("responds with expected message for promise", function() {
                 testApp.launch(function(req, res) {
                   return Promise.resolve().then(function() {

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -280,7 +280,7 @@ describe("Alexa", function() {
 
         it("session.clear() should fail the app", function() {
           testApp.pre = function(req, res, type) {
-            req.getSession().clear();
+            return req.getSession().clear();
           };
 
           var subject = testApp.request(mockRequest);

--- a/test/test_alexa_app_unknown_type_request.js
+++ b/test/test_alexa_app_unknown_type_request.js
@@ -63,7 +63,7 @@ describe("Alexa", function() {
         it("responds with a spoken message for uncaught errors in the globally defined error function and resolves", function() {
           testApp.error = function(e, request, response) {
             response.say("Sorry, something bad happened");
-            response.send();
+            return response.send();
           };
 
           var subject = testApp.request(mockRequest).then(function(response) {
@@ -78,7 +78,7 @@ describe("Alexa", function() {
         it("responds with a spoken message for uncaught errors in the globally defined error function and fails", function() {
           testApp.error = function(e, request, response) {
             response.say("Sorry, something bad happened");
-            response.fail(e);
+            return response.fail(e);
           };
 
           var subject = testApp.request(mockRequest).then(function(response) {


### PR DESCRIPTION
This completes the change for #134. Asynchronous support is no longer backwards compatible, and the `return false` and callbacks to handlers have been removed. Now, returning Promises from handlers is required for asynchronous support.

`pre` and `post` now both also have asynchronous support. The API functions identically as before as long as you use the Promise chain for asynchronicity. `response.send` and `response.fail` can force immediate success or failure. `.post` can still recover failures. The `response.send` and `response.fail` methods return promises that must be returned from inside the promise chain in order to continue it.

Also closes #22 