### PR TITLE
Implement slot defaults without exception, add test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 * [#174](https://github.com/alexa-js/alexa-app/pull/174): Always enfore strict header checking - [@tejashah88](https://github.com/tejashah88).
 * Your contribution here.
 
+### 3.1.2 (February 16, 2017)
+
+* [#184](https://github.com/alexa-js/alexa-app/pull/184): Implement slot defaults without exception, add test - [@rickwargo](https://github.com/rickwargo).
+
 ### 3.1.0 (February 13, 2017)
 
 * [#162](https://github.com/alexa-js/alexa-app/issues/162): Fix: do not generate empty slots in schema - [@dblock](https://github.com/dblock).

--- a/index.js
+++ b/index.js
@@ -176,7 +176,11 @@ alexa.request = function(json) {
   this.data = json;
   this.slot = function(slotName, defaultValue) {
     try {
-      return this.data.request.intent.slots[slotName].value;
+      if (this.data.request.intent.slots && slotName in this.data.request.intent.slots) {
+        return this.data.request.intent.slots[slotName].value;
+      } else {
+        return defaultValue;
+      }
     } catch (e) {
       console.error("missing intent in request: " + slotName, e);
       return defaultValue;

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -350,6 +350,26 @@ describe("Alexa", function() {
               });
             });
           });
+
+          context("with a manipulated intent request", function() {
+            it("retrieves default slot value due to missing intent", function() {
+                testApp.intent("airportInfoIntent", {}, function(req, res) {
+                  delete req.data.request.intent; // remove intent from request
+                  res.say(req.slot("InvalidSlotName", "default value"));
+                  return true;
+                });
+
+                var subject = testApp.request(mockRequest);
+                subject = subject.then(function(response) {
+                  return response.response.outputSpeech;
+                });
+
+                return expect(subject).to.eventually.become({
+                  ssml: "<speak>default value</speak>",
+                  type: "SSML"
+                });
+            });
+          });
         });
       });
     });


### PR DESCRIPTION
No need to cause unwarranted exception about a missing intent when the intent is there, the default is not. This PR checks to see if the slot does not exist and returns the default value if not. Existing test covers this code path. Add test for getting default value when the request is actually missing the intent.