### PR TITLE
Add PlaybackController Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises and removing `return false`/callback functionality - [@ajcrites](https://github.com/ajcrites).
 * [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).
 * [#188](https://github.com/alexa-js/alexa-app/issues/188): Use `callback` to complete lambda functions rather than `context`. - [@ajcrites](https://github.com/ajcrites).
-* [#199](https://github.com/alexa-js/alexa-app/issues/199) Add support for `PlaybackController` events
+* [#199](https://github.com/alexa-js/alexa-app/issues/199): Add support for `PlaybackController` events - [@tternes](http://github.com/tternes).
 * Your contribution here.
 
 ### 3.2.0 (February 24, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises and removing `return false`/callback functionality - [@ajcrites](https://github.com/ajcrites).
 * [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).
 * [#188](https://github.com/alexa-js/alexa-app/issues/188): Use `callback` to complete lambda functions rather than `context`. - [@ajcrites](https://github.com/ajcrites).
+* [#199](https://github.com/alexa-js/alexa-app/issues/199) Add support for `PlaybackController` events
 * Your contribution here.
 
 ### 3.2.0 (February 24, 2017)

--- a/README.md
+++ b/README.md
@@ -349,6 +349,35 @@ app.audioPlayer("PlaybackFinished", function(request, response) {
 ```
 
 
+### PlaybackController Event Request
+
+PlaybackController events are sent to your skill when the user interacts with player controls on a device. Define multiple handlers for various events by making multiple calls to `playbackController` with each event type.
+
+You can define handlers for the following events:
+
+* PlayCommandIssued
+* PauseCommandIssued
+* NextCommandIssued
+* PreviousCommandIssued
+
+Read more about PlaybackController requests in the [PlaybackController Interface Reference](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-playbackcontroller-interface-reference).
+
+The following example will send a play directive to the device when a user presses the "next" button.
+
+```javascript
+app.playbackController('NextCommandIssued', (request, response) => {
+  var stream = {
+    "url": "https://next-song-url",
+    "token": "some_token",
+    "expectedPreviousToken": "some_previous_token",
+    "offsetInMilliseconds": 0
+  };
+  response.audioPlayerPlayStream("REPLACE_ALL", stream);
+});
+```
+
+Note that some device interactions don't always produce PlaybackController events. See the [PlaybackController Interface Introduction](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/custom-playbackcontroller-interface-reference#introduction) for more details.
+
 ## Execute Code On Every Request
 
 In addition to specific event handlers, you can define functions that will run on every request.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     * [IntentRequest](#intentrequest)
     * [SessionEndRequest](#sessionendrequest)
     * [AudioPlayer Event Request](#audioplayer-event-request)
+    * [PlaybackController Event Request](#playbackcontroller-event-request)
 * [Execute Code On Every Request](#execute-code-on-every-request)
     * [pre()](#pre)
     * [post()](#post)

--- a/index.js
+++ b/index.js
@@ -197,6 +197,10 @@ alexa.request = function(json) {
     var requestType = this.type();
     return (requestType && 0 === requestType.indexOf("AudioPlayer."));
   };
+  this.isPlaybackController = function() {
+    var requestType = this.type();
+    return (requestType && 0 === requestType.indexOf("PlaybackController."));
+  };
 
   this.userId = null;
   this.applicationId = null;
@@ -344,6 +348,13 @@ alexa.app = function(name) {
       "function": func
     };
   };
+  this.playbackControllerEventHandlers = {};
+  this.playbackController = function(eventName, func) {
+    self.playbackControllerEventHandlers[eventName] = {
+      "name": eventName,
+      "function": func
+    };
+  }
   this.launchFunc = null;
   this.launch = function(func) {
     self.launchFunc = func;
@@ -421,6 +432,12 @@ alexa.app = function(name) {
         } else if (request.isAudioPlayer()) {
           var event = requestType.slice(12);
           var eventHandlerObject = self.audioPlayerEventHandlers[event];
+          if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
+            return Promise.resolve(eventHandlerObject["function"](request, response));
+          }
+        } else if (request.isPlaybackController()) {
+          var event = requestType.slice(19);
+          var eventHandlerObject = self.playbackControllerEventHandlers[event];
           if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
             return Promise.resolve(eventHandlerObject["function"](request, response));
           }

--- a/index.js
+++ b/index.js
@@ -354,7 +354,7 @@ alexa.app = function(name) {
       "name": eventName,
       "function": func
     };
-  }
+  };
   this.launchFunc = null;
   this.launch = function(func) {
     self.launchFunc = func;
@@ -436,10 +436,10 @@ alexa.app = function(name) {
             return Promise.resolve(eventHandlerObject["function"](request, response));
           }
         } else if (request.isPlaybackController()) {
-          var event = requestType.slice(19);
-          var eventHandlerObject = self.playbackControllerEventHandlers[event];
-          if (typeof eventHandlerObject != "undefined" && typeof eventHandlerObject["function"] == "function") {
-            return Promise.resolve(eventHandlerObject["function"](request, response));
+          var playbackControllerEvent = requestType.slice(19);
+          var playbackEventHandlerObject = self.playbackControllerEventHandlers[playbackControllerEvent];
+          if (typeof playbackEventHandlerObject != "undefined" && typeof playbackEventHandlerObject["function"] == "function") {
+            return Promise.resolve(playbackEventHandlerObject["function"](request, response));
           }
         } else {
           throw "INVALID_REQUEST_TYPE";

--- a/test/fixtures/playback_controller_play_command.json
+++ b/test/fixtures/playback_controller_play_command.json
@@ -1,0 +1,21 @@
+{
+  "version": "string",
+  "context": {
+    "System": {
+      "application": {},
+      "user": {},
+      "device": {}
+    },
+    "AudioPlayer": {
+      "token": "string",
+      "offsetInMilliseconds": 0,
+      "playerActivity": "string"
+    }
+  },
+  "request": {
+    "type": "PlaybackController.PlayCommandIssued",
+    "requestId": "string",
+    "timestamp": "string",
+    "locale": "string"
+  }
+}

--- a/test/test_alexa_app_playbackcontroller.js
+++ b/test/test_alexa_app_playbackcontroller.js
@@ -1,0 +1,74 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+var mockHelper = require("./helpers/mock_helper");
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+chai.config.includeStack = true;
+var Promise = require("bluebird");
+
+
+describe("Alexa", function () {
+  var Alexa = require("../index");
+
+  describe("app", function () {
+    var testApp;
+    var playbackHandlerWasCalled;
+    var playbackControllerHandler = function(req, res) {
+      playbackHandlerWasCalled = true;
+    };
+    beforeEach(function() {
+      playbackHandlerWasCalled = false;
+      testApp = new Alexa.app("testApp");
+    });
+
+    describe("request", function () {
+
+      context("with a playback controller command", function() {
+        var mockRequest;
+        beforeEach(function() { mockRequest = mockHelper.load("playback_controller_play_command.json");});
+
+        it("should not return speech output", function() {
+          return testApp.request(mockRequest)
+            .should.eventually.be.fulfilled
+            .and.not.have.deep.property("response.outputSpeech.type");
+        });
+
+        it("should call the matching playbackController handler", function() {
+          testApp.playbackController("PlayCommandIssued", playbackControllerHandler);
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return playbackHandlerWasCalled;
+          });
+
+          return expect(subject).to.eventually.become(true);
+        });
+
+        it("should not call other playbackController handlers", function() {
+          testApp.playbackController("PreviousCommandIssued", playbackControllerHandler);
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return playbackHandlerWasCalled;
+          });
+
+          return expect(subject).to.eventually.become(false);
+        });
+      });
+
+      context("without a playback controller command", function() {
+        var mockRequest;
+        beforeEach(function() { mockRequest = mockHelper.load("intent_request_airport_info.json"); });
+
+        it("should not call the playbackController handler", function() {
+          testApp.playbackController("PlayCommandIssued", playbackControllerHandler);
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return playbackHandlerWasCalled;
+          });
+
+          return expect(subject).to.eventually.become(false);
+        });
+
+      });
+    });
+
+  });
+});


### PR DESCRIPTION
This changes adds initial support for `PlaybackController` events. Currently, the skill will produce invalid responses to these events, causing follow-up errors to be sent to the skill by Alexa.

This is my first contribution to this project, so feedback and suggestions for improvement is greatly appreciated.

This should resolve #199.