### PR TITLE
Fix Syntax of Session Details to match with Docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 3.0.1 (Next)
+
+* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fix Syntax of Session Details to match with Docs - [@danielstieber](https://github.com/danielstieber).
+* Your contribution here.
+
 ### 4.0.0 (March 20, 2017)
 * [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises, removed `return false`/callback support - [@ajcrites](https://github.com/ajcrites).
 * [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
 ## Changelog
 
-### 4.0.0 (Next)
+### 4.0.0 (March 20, 2017)
 * [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises, removed `return false`/callback support - [@ajcrites](https://github.com/ajcrites).
 * [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).
 * [#188](https://github.com/alexa-js/alexa-app/issues/188): Use `callback` to complete lambda functions rather than `context`. - [@ajcrites](https://github.com/ajcrites).
 * [#199](https://github.com/alexa-js/alexa-app/issues/199): Add support for `PlaybackController` events - [@tternes](http://github.com/tternes).
 * [#203](https://github.com/alexa-js/alexa-app/issues/203): Fix: utterances separated by space instead of tab - [@jmihalicza](http://github.com/jmihalicza).
-* Your contribution here.
 
 ### 3.2.0 (February 24, 2017)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## Changelog
 
-### 3.0.1 (Next)
+### 4.0.1 (Next)
 
-* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fix Syntax of Session Details to match with Docs - [@danielstieber](https://github.com/danielstieber).
+* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed syntax of session.details to match with session as passed by Alexa. - [@danielstieber](https://github.com/danielstieber).
 * Your contribution here.
 
 ### 4.0.0 (March 20, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## Changelog
 
 ### 4.0.0 (Next)
-* [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises and removing `return false`/callback functionality - [@ajcrites](https://github.com/ajcrites).
+* [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises, removed `return false`/callback support - [@ajcrites](https://github.com/ajcrites).
 * [#22](https://github.com/alexa-js/alexa-app/issues/22): Asynchronous support for `pre` and `post` - [@ajcrites](https://github.com/ajcrites).
 * [#188](https://github.com/alexa-js/alexa-app/issues/188): Use `callback` to complete lambda functions rather than `context`. - [@ajcrites](https://github.com/ajcrites).
 * [#199](https://github.com/alexa-js/alexa-app/issues/199): Add support for `PlaybackController` events - [@tternes](http://github.com/tternes).
-* [#203](https://github.com/alexa-js/alexa-app/issues/203): /utterances: separator fix (tab -> space) - [@jmihalicza](http://github.com/jmihalicza).
+* [#203](https://github.com/alexa-js/alexa-app/issues/203): Fix: utterances separated by space instead of tab - [@jmihalicza](http://github.com/jmihalicza).
 * Your contribution here.
 
 ### 3.2.0 (February 24, 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.1 (Next)
 
-* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed syntax of session.details to match with session as passed by amazon. - [@danielstieber](https://github.com/danielstieber).
+* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed syntax of session.details to match with session as passed by alexa - [@danielstieber](https://github.com/danielstieber).
 * [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.1 (Next)
 
-* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed syntax of session.details to match with session as passed by alexa - [@danielstieber](https://github.com/danielstieber).
+* [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed syntax of session.details to match with session as passed by Amazon - [@danielstieber](https://github.com/danielstieber).
 * [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A Node module to simplify the development of Alexa skills (applications.)
 
 ## Stable Release
 
-You're reading the documentation for the next release of alexa-app. Please see [CHANGELOG](CHANGELOG.md) and make sure to read [UPGRADING](UPGRADING.md) when upgrading from a previous version. The current stable release is [3.2.0](https://github.com/alexa-js/alexa-app/tree/v3.2.0).
+You're reading the documentation for the next release of alexa-app. Please see [CHANGELOG](CHANGELOG.md) and make sure to read [UPGRADING](UPGRADING.md) when upgrading from a previous version. The current stable release is [4.0.0](https://github.com/alexa-js/alexa-app/tree/v4.0.0).
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ session.set(String attributeName, String attributeValue)
 String session.get(String attributeName)
 
 // session details, as passed by Amazon in the request
+// for Object definition @see https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#session-object
 session.details = { ... }
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,29 @@
 # Upgrading Alexa-app
 
+### Upgrading to >= 4.0.1
+
+#### Changes session details syntax
+
+The session details will now be filled one-to-one by the given Alexa session information. According to that, the syntax of the user data has slightly changed. UserId and accessToken are now nested inside a user object.
+
+Before:
+```javascript
+// Get userId (marked as deprecated)
+request.getSession().details.userId;
+// Get accessToken (marked as deprecated)
+request.getSession().details.accessToken;
+```
+
+After:
+```javascript
+// Get userId
+request.getSession().details.user.userId;
+// Get accessToken
+request.getSession().details.user.accessToken;
+```
+
+See [#215](https://github.com/alexa-js/alexa-app/pull/215) for more information.
+
 ### Upgrading to >= 4.0.0
 
 #### Changes to Asynchronous Support

--- a/index.js
+++ b/index.js
@@ -259,16 +259,14 @@ alexa.session = function(session) {
         this.attributes = {};
       }
     };
-    this.details = {
-      "new": session.new,
-      "sessionId": session.sessionId,
-      "user": {
-        "userId": session.user.userId,
-        "accessToken": session.user.accessToken || null
-      },
-      "attributes": session.attributes,
-      "application": session.application
-    };
+    // load the alexa session information into details
+    this.details = session;
+    
+    // @deprecated
+    this.details.userId = this.details.user.userId || null;
+    // @deprecated
+    this.details.accessToken = this.details.user.accessToken || null;
+
     // persist all the session attributes across requests
     // the Alexa API doesn't think session variables should persist for the entire
     // duration of the session, but I do

--- a/index.js
+++ b/index.js
@@ -266,12 +266,11 @@ alexa.session = function(session) {
     };
     // load the alexa session information into details
     this.details = session;
-    
     // @deprecated
     this.details.userId = this.details.user.userId || null;
     // @deprecated
     this.details.accessToken = this.details.user.accessToken || null;
-
+    
     // persist all the session attributes across requests
     // the Alexa API doesn't think session variables should persist for the entire
     // duration of the session, but I do

--- a/index.js
+++ b/index.js
@@ -262,7 +262,7 @@ alexa.session = function(session) {
     this.details = {
       "new": session.new,
       "sessionId": session.sessionId,
-      "user" : {
+      "user": {
         "userId": session.user.userId,
         "accessToken": session.user.accessToken || null
       },

--- a/index.js
+++ b/index.js
@@ -262,8 +262,10 @@ alexa.session = function(session) {
     this.details = {
       "new": session.new,
       "sessionId": session.sessionId,
-      "userId": session.user.userId,
-      "accessToken": session.user.accessToken || null,
+      "user" : {
+        "userId": session.user.userId,
+        "accessToken": session.user.accessToken || null
+      },
       "attributes": session.attributes,
       "application": session.application
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-app",
-  "version": "3.2.0",
+  "version": "4.0.0",
   "description": "A module to simplify creation of Alexa (Amazon Echo) apps (Skills) using Node.js",
   "main": "index.js",
   "author": "Matt Kruse <github@mattkruse.com> (http://mattkruse.com)",

--- a/test/fixtures/intent_request_airport_info.json
+++ b/test/fixtures/intent_request_airport_info.json
@@ -9,7 +9,9 @@
     "attributes": {},
     "user": {
       "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
-    }
+    },
+    "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+    "accessToken": null
   },
   "request": {
     "type": "IntentRequest",


### PR DESCRIPTION
Hey, 

when I installed VoiceLabs analytics modul, I realized that it expects the original Request Body Syntax of a Session (in the Docs:https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#request-body-syntax).

Alexa-app is currently not providing the right syntax as you can see on the comparison of the files. 

I added an additional user tier, just as it is in the Alexa Docs to fix this.