### PR TITLE
Fix cert check test cases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.0.1 (Next)
 
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
+* [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 
 
 ### 4.0.0 (March 20, 2017)
 * [#134](https://github.com/alexa-js/alexa-app/issues/134): Asynchronous support purely through Promises, removed `return false`/callback support - [@ajcrites](https://github.com/ajcrites).

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -192,7 +192,7 @@ describe("Alexa", function() {
           .post('/testApp')
           .expect(401).then(function(res) {
             expect(res.body.status).to.equal("failure");
-            expect(res.body.reason).to.equal("signature is not base64 encoded");
+            expect(res.body.reason).to.equal("missing certificate url");
           });
       });
 
@@ -203,7 +203,7 @@ describe("Alexa", function() {
           .set('signature', 'dummy')
           .expect(401).then(function(res) {
             expect(res.body.status).to.equal("failure");
-            expect(res.body.reason).to.equal("signature is not base64 encoded");
+            expect(res.body.reason).to.equal("missing request (certificate) body");
           });
       });
 
@@ -217,7 +217,7 @@ describe("Alexa", function() {
           .send(mockRequest)
           .expect(401).then(function(res) {
             expect(res.body.status).to.equal("failure");
-            expect(res.body.reason).to.equal("signature is not base64 encoded");
+            expect(res.body.reason).to.equal("invalid signature (not base64 encoded)");
           });
       });
 


### PR DESCRIPTION
The error messages from alexa-verifier were changed in mreinstein/alexa-verifier@cde450b90078b52eb45a5e865f3083d30fa382da causing integration tests to fail.