### PR TITLE
added AskForPermissionConsent card as well as test case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.1 (Next)
 
-* [#223](https://github.com/alexa-js/alexa-app/issues/223): new card type available, AskForPermissionsConsent - [@ericblade]
+* [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 
 * [#220](https://github.com/alexa-js/alexa-app/pull/220): No longer compatible with Node 0.12 - [@adrianba](https://github.com/adrianba). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.0.1 (Next)
 
+* [#223](https://github.com/alexa-js/alexa-app/issues/223): new card type available, AskForPermissionsConsent - [@ericblade]
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 
 * [#220](https://github.com/alexa-js/alexa-app/pull/220): No longer compatible with Node 0.12 - [@adrianba](https://github.com/adrianba). 

--- a/README.md
+++ b/README.md
@@ -548,6 +548,8 @@ The `response.card(Object card)` method allows you to send [Home Cards](https://
 
 The full specification for the `card` object passed to this method can be found [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#card-object).
 
+The full specification for the permission card can be found [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#sample-response-with-permission-card)
+
 Cards do not support SSML
 
 If you just want to display a card that presents the user to link their account call `response.linkAccount()` as a shortcut.
@@ -578,6 +580,17 @@ response.card({
     smallImageUrl: "https://carfu.com/resources/card-images/race-car-small.png", // required
     largeImageUrl: "https://carfu.com/resources/card-images/race-car-large.png"
   }
+});
+```
+
+Display a card that presents the user to grant information to your skill, aka [AskForPermissionsConsent](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#sample-response-with-permission-card)
+
+If the request was for the country and postal code, then the permissions value in this response will be “read::alexa:device:all:address:country_and_postal_code”.
+
+```javascript
+response.card({
+  type: "AskForPermissionsConsent",
+  permissions: [ "read::alexa:device:all:address" ] // full address
 });
 ```
 

--- a/README.md
+++ b/README.md
@@ -548,9 +548,9 @@ The `response.card(Object card)` method allows you to send [Home Cards](https://
 
 The full specification for the `card` object passed to this method can be found [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#card-object).
 
-The full specification for the permission card can be found [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#sample-response-with-permission-card)
+The full specification for the permission card can be found [here](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#sample-response-with-permission-card).
 
-Cards do not support SSML
+Cards do not support SSML.
 
 If you just want to display a card that presents the user to link their account call `response.linkAccount()` as a shortcut.
 

--- a/index.js
+++ b/index.js
@@ -77,6 +77,9 @@ alexa.response = function(session) {
           return this;
         }
         break;
+      case 'AskForPermissionsConsent':
+        requiredAttrs.push('permissions');
+        break;
       default:
         break;
     }

--- a/test/test_alexa_app_cards.js
+++ b/test/test_alexa_app_cards.js
@@ -171,6 +171,34 @@ describe("Alexa", function() {
               ]);
             });
 
+            it("responds with ask for permissions concent", function() {
+              var oCard = {
+                  type: "AskForPermissionsConsent",
+                  permissions: ['read::alexa:device:all:address:country_and_postal_code']
+                },
+                expectedCard = JSON.parse(JSON.stringify(oCard));
+
+              intentHandler = function(req, res) {
+                res.say(expectedMessage).card(oCard);
+                return true;
+              };
+              setupIntentHandler(intentHandler);
+              var subject = testApp.request(mockRequest);
+              var alexaResponse = subject.then(function(response) {
+                return response.response.outputSpeech;
+              });
+              var cardResponse = subject.then(function(response) {
+                return response.response.card;
+              });
+              return Promise.all([
+                expect(alexaResponse).to.eventually.become({
+                  ssml: "<speak>" + expectedMessage + "</speak>",
+                  type: "SSML"
+                }),
+                expect(cardResponse).to.eventually.become(expectedCard),
+              ]); 
+            });
+
             it("responds with a speech and no card because it was called with invalid info", function() {
               var oCard = {
                   type: "Standard",


### PR DESCRIPTION
I wanted to check the consent exists in every request, so I wrote the example is as following:

```
app.pre = function(request, response, type) {
  if (!request.context.System.user.permissions || !request.context.System.user.permissions.consentToken) {
    response.say("please enable your location. I have sent the permission card to your companion app. Just go to alexa.amazon.com to enable it.");
    response.card({
      type: 'AskForPermissionsConsent',
      permissions: [ 'read::alexa:device:all:address:country_and_postal_code' ]
    });
    response.fail('location is required');
  }
}
```
Hope this helps~ 
Thank you :)