### PR TITLE
Add properties for device ID and consent token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ Temporary Items
 
 # IDE
 .idea
+.vs
 .vscode
 
 # NPM

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.0.1 (Next)
 
-* [#226](https://github.com/alexa-js/alexa-app/pull/226): Added properties for device ID and consent token - [@martincostello](https://github.com/martincostello).
+* [#226](https://github.com/alexa-js/alexa-app/pull/226): Added properties for API endpoint, consent token and device ID - [@martincostello](https://github.com/martincostello).
 * [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.0.1 (Next)
 
+* [#226](https://github.com/alexa-js/alexa-app/pull/226): Added properties for device ID and consent token - [@martincostello](https://github.com/martincostello).
 * [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).
 * [#218](https://github.com/alexa-js/alexa-app/pull/218): Fix cert check test cases - [@adrianba](https://github.com/adrianba). 

--- a/index.js
+++ b/index.js
@@ -208,11 +208,21 @@ alexa.request = function(json) {
   this.userId = null;
   this.applicationId = null;
   this.context = null;
+  this.deviceId = null;
+  this.consentToken = null;
 
   if (this.data.context) {
     this.userId = this.data.context.System.user.userId;
     this.applicationId = this.data.context.System.application.applicationId;
     this.context = this.data.context;
+
+    if (this.data.context.System.device) {
+      this.deviceId = this.data.context.System.device.deviceId;
+    }
+
+    if (this.data.context.System.user.permissions) {
+      this.consentToken = this.data.context.System.user.permissions.consentToken;
+    }
   }
 
   var session = new alexa.session(json.session);

--- a/index.js
+++ b/index.js
@@ -210,6 +210,7 @@ alexa.request = function(json) {
   this.context = null;
   this.deviceId = null;
   this.consentToken = null;
+  this.apiEndpoint = null;
 
   if (this.data.context) {
     this.userId = this.data.context.System.user.userId;
@@ -222,6 +223,10 @@ alexa.request = function(json) {
 
     if (this.data.context.System.user.permissions) {
       this.consentToken = this.data.context.System.user.permissions.consentToken;
+    }
+
+    if (this.data.context.System.apiEndpoint) {
+      this.apiEndpoint = this.data.context.System.apiEndpoint;
     }
   }
 

--- a/test/fixtures/intent_request_airport_info_with_consent_token.json
+++ b/test/fixtures/intent_request_airport_info_with_consent_token.json
@@ -39,7 +39,8 @@
       "device": {
         "deviceId": "MyDeviceId",
         "supportedInterfaces": {}
-      }
+      },
+      "apiEndpoint": "https://api.amazonalexa.com/"
     }
   }
 }

--- a/test/fixtures/intent_request_airport_info_with_consent_token.json
+++ b/test/fixtures/intent_request_airport_info_with_consent_token.json
@@ -1,0 +1,45 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+    }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "airportInfoIntent",
+      "slots": {
+        "AirportCode": {
+          "name": "AirportCode",
+          "value": "JFK"
+        }
+      }
+    }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+        "permissions": {
+          "consentToken": "Atza|MQEWY...6fnLok"
+        }
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      },
+      "device": {
+        "deviceId": "MyDeviceId",
+        "supportedInterfaces": {}
+      }
+    }
+  }
+}

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -74,6 +74,14 @@ describe("Alexa", function() {
             expect(subject).to.eventually.have.property(
               "userId",
               "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+            ),
+            expect(subject).to.eventually.have.property(
+                "deviceId",
+                null
+            ),
+            expect(subject).to.eventually.have.property(
+                "consentToken",
+                null
             )
           ]);
         });
@@ -437,6 +445,53 @@ describe("Alexa", function() {
           });
 
         });
+      });
+    });
+
+    describe("#request", function() {
+      context("request with consent token", function() {
+        var mockRequest = mockHelper.load("intent_request_airport_info_with_consent_token.json");
+        var reqObject;
+
+        beforeEach(function() {
+          var intentHandler = function(req, res) {
+            res.say("message").shouldEndSession(false);
+            res.session("foo", true);
+            res.session("bar", {
+              qaz: "woah"
+            });
+            reqObject = req;
+            return true;
+          };
+
+          testApp.intent("airportInfoIntent", {}, intentHandler);
+        });
+
+        it("has a res object with expected properties", function() {
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return reqObject;
+          });
+
+          return Promise.all([
+            expect(subject).to.eventually.have.property(
+              "applicationId",
+              "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+            ),
+            expect(subject).to.eventually.have.property(
+              "userId",
+              "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+            ),
+            expect(subject).to.eventually.have.property(
+                "deviceId",
+                "MyDeviceId"
+            ),
+            expect(subject).to.eventually.have.property(
+                "consentToken",
+                "Atza|MQEWY...6fnLok"
+            )
+          ]);
+        });
+
       });
     });
   });

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -82,6 +82,10 @@ describe("Alexa", function() {
             expect(subject).to.eventually.have.property(
                 "consentToken",
                 null
+            ),
+            expect(subject).to.eventually.have.property(
+                "apiEndpoint",
+                null
             )
           ]);
         });
@@ -488,6 +492,10 @@ describe("Alexa", function() {
             expect(subject).to.eventually.have.property(
                 "consentToken",
                 "Atza|MQEWY...6fnLok"
+            ),
+            expect(subject).to.eventually.have.property(
+                "apiEndpoint",
+                "https://api.amazonalexa.com/"
             )
           ]);
         });


### PR DESCRIPTION
Add properties to the Alexa request to easily access the device ID and content token, for example for use after returning a permission card to access the device's address.

  * [Getting the device ID and consent token](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#get-the-consent-token-and-device-id)
  * [Getting a device's address](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/device-address-api#getCountryAndPostalCode)