### PR TITLE
Update ssml.cleanse to stop removing spaces before decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.0.1 (Next)
 
+* [#236](https://github.com/alexa-js/alexa-app/pull/236): Update `ssml.cleanse` to stop removing spaces before decimals - [@aminimalanimal](https://github.com/aminimalanimal).
 * [#215](https://github.com/alexa-js/alexa-app/pull/215): Fixed `session.details` to match with session in the request object - [@danielstieber](https://github.com/danielstieber).
 * [#223](https://github.com/alexa-js/alexa-app/issues/223): Added support for `AskForPermissionsConsent` cards - [@ericblade](https://github.com/ericblade).
 * [#219](https://github.com/alexa-js/alexa-app/pull/219): Preserve session when clearing non-existent attribute - [@adrianba](https://github.com/adrianba).

--- a/lib/to-ssml.js
+++ b/lib/to-ssml.js
@@ -31,7 +31,7 @@ var ssml = {
   },
   cleanse: function(str) {
     // <p> is left in place to support intended HTML output
-    return str.replace(/<\/?(speak|break|phoneme|audio|say-as|s\b|w\b)[^>]*>/gi, " ")
+    return str.replace(/<\/?(speak|break|phoneme|audio|say-as|s\b|w\b)[^>]*>/gi, "")
       .replace(/\s*\n\s*/g, "\n")
       .replace(/  +/g, " ")
       .replace(/ ([,!?;:])/g, "$1")

--- a/lib/to-ssml.js
+++ b/lib/to-ssml.js
@@ -34,7 +34,7 @@ var ssml = {
     return str.replace(/<\/?(speak|break|phoneme|audio|say-as|s\b|w\b)[^>]*>/gi, " ")
       .replace(/\s*\n\s*/g, "\n")
       .replace(/  +/g, " ")
-      .replace(/ ([.,!?;:])/g, "$1")
+      .replace(/ ([,!?;:])/g, "$1")
       .trim();
   }
 };

--- a/test/test_ssml.js
+++ b/test/test_ssml.js
@@ -154,6 +154,13 @@ describe('SSML', function() {
           return SSML.cleanse(input).should.equal(expectedOutput);
         });
 
+        it('should not truncate spaces before periods', function() {
+          var input = '.1, .2, and .3';
+          var expectedOutput = '.1, .2, and .3';
+
+          return SSML.cleanse(input).should.equal(expectedOutput);
+        });
+
       });
     });
   });


### PR DESCRIPTION
alexa-app was unexpectedly stripping spaces that occur before periods. Since periods are also decimals, this produced issues with the expected output of our bartender app's card text.

Things like:
> Ingredients: 2 oz Tanqueray No. TEN Gin, .5 oz Heavy cream, .5 oz Fresh lemon juice, .5 oz Fresh lime juice, .75 oz Simple syrup (one part sugar, one part water), 3 dashes Orange flower water, 1 Fresh egg white, and Club soda

were showing up as:
> Ingredients: 2 oz Tanqueray No. TEN Gin,.5 oz Heavy cream,.5 oz Fresh lemon juice,.5 oz Fresh lime juice,.75 oz Simple syrup (one part sugar, one part water), 3 dashes Orange flower water, 1 Fresh egg white, and Club soda

I think that this sort of cleansing should probably not be done at all, instead letting app developers to have control over their output, but this PR only removes the item that affected us. Perhaps the others will always be ideal to strip spaces for, but it's a hard thing to predict—after all, our use-case wasn't immediately obvious. :)