### PR TITLE
Preparing for next development iteration, 4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+### 4.0.2 (Next)
+* Your contribution here
+
 ### 4.0.1 (May 17, 2017)
 
 * [#236](https://github.com/alexa-js/alexa-app/pull/236): Update `ssml.cleanse` to stop removing spaces before decimals - [@aminimalanimal](https://github.com/aminimalanimal).

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A Node module to simplify the development of Alexa skills (applications.)
 
 ## Stable Release
 
-You're reading the documentation for the next release of alexa-app. Please see [CHANGELOG](CHANGELOG.md) and make sure to read [UPGRADING](UPGRADING.md) when upgrading from a previous version. The current stable release is [4.0.1](https://github.com/alexa-js/alexa-app/tree/v4.0.1).
+You're reading the documentation for the next release of alexa-app, which should be 4.0.2. Please see [CHANGELOG](CHANGELOG.md) and make sure to read [UPGRADING](UPGRADING.md) when upgrading from a previous version. The current stable release is [4.0.1](https://github.com/alexa-js/alexa-app/tree/v4.0.1).
 
 ## Introduction
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-app",
-  "version": "4.0.1",
+  "version": "4.0.2-beta",
   "description": "A module to simplify creation of Alexa (Amazon Echo) apps (Skills) using Node.js",
   "main": "index.js",
   "author": "Matt Kruse <github@mattkruse.com> (http://mattkruse.com)",


### PR DESCRIPTION
I've also published an npm tag, `next` for this 4.0.2-beta version. We can continue to publish on top of this version to allow users to get upcoming changes.

This prevents users from having to install directly from the repo to get future changes which was happening for some of the session fixes we had made for 4.0.1 pre-release.