### PR TITLE
Resolve: Updating request.type() in app.pre is ignored in later stages

### DIFF
--- a/index.js
+++ b/index.js
@@ -491,6 +491,7 @@ alexa.app = function(name) {
       return prePromise;
     }).then(function () {
       if (!response.resolved) {
+        requestType = request.type();
         if ("IntentRequest" === requestType) {
           var intent = request_json.request.intent.name;
           if (typeof self.intents[intent] !== "undefined" && typeof self.intents[intent].handler === "function") {


### PR DESCRIPTION
There is a small bug in the current repository where if you change the value of what request.type() would return in your app.pre() function, it is not picked up before the request is acted on.  By relearning what requestType is later, this bug can be fixed.