### PR TITLE
Support for outputting Skill Builder Beta schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#271](https://github.com/alexa-js/alexa-app/pull/271): Update request typing - [@jontg](https://github.com/jontg).
 * [#269](https://github.com/alexa-js/alexa-app/pull/269): Fix the lambda() type definition - [@jontg](https://github.com/jontg).
+* [#268](https://github.com/alexa-js/alexa-app/pull/268): Add support for outputting new Skill Builder schema - [@lazerwalker](https://github.com/lazerwalker).
 * Your contribution here
 
 ### 4.1.0 (August 12, 2017)

--- a/README.md
+++ b/README.md
@@ -513,7 +513,7 @@ app.post = function(request, response, type, exception) {
 
 ## Schema and Utterances
 
-The alexa-app module makes it easy to define your intent schema and generate many sample utterances. Optionally pass your schema definition along with your intent handler, and extract the generated content using the `schema()` and `utterances()` functions on your app.
+The alexa-app module makes it easy to define your intent schema and generate many sample utterances. Optionally pass your schema definition along with your intent handler, and extract the generated content using either the `schemas.intent()` and `utterances()` functions on your app (if using the normal Developer portal) or `schemas.skillBuilder()` if using the new Skill Builder beta.
 
 
 ### Schema Syntax
@@ -586,11 +586,16 @@ app.dictionary = {"colors":["red","green","blue"]};
 
 ### Generating Schema and Utterances Output
 
-To get the generated content out of your app, call the `schema()` and `utterances()` functions. See [example/express.js](example/express.js) for one way to output this data.
+#### Intent Schema Syntax
+
+If you are using the normal Amazon developer portal, the `schemas.intent()` and `utterances()` functions will generate an
+intent schema JSON string and a list of utterances, respectively.
+
+See [example/express.js](example/express.js) for one way to output this data.
 
 ```javascript
-// returns a String representation of the JSON object
-app.schema() =>
+// returns a String representation of an Intent Schema JSON object
+app.schemas.intent() =>
 
 {
   "intents": [{
@@ -617,6 +622,31 @@ WhatsMyColorIntent what is my favorite color
 WhatsMyColorIntent say my favorite color
 WhatsMyColorIntent tell me my favorite color
 WhatsMyColorIntent tell me what my favorite color is
+```
+
+#### Skill Builder Syntax
+
+If you are using the Skill Builder Beta, the `schemas.skillBuilder()` function will generate a single schema JSON string
+that includes your intents with all of their utterances
+```javascript
+app.schemas.intent() =>
+
+{
+  "intents": [{
+    "name": "MyColorIsIntent",
+    "samples": [
+      "my color is {dark brown|Color}",
+      "my color is {green|Color}",
+      "my favorite color is {red|Color}",
+      "my favorite color is {navy blue|Color}"
+    ],
+    "slots": [{
+      "name": "Color",
+      "type": "AMAZON.Color",
+      "samples": []
+    }]
+  }]
+}
 ```
 
 ## Cards

--- a/index.js
+++ b/index.js
@@ -582,73 +582,74 @@ alexa.app = function(name) {
     });
   };
 
-  // extract the schema and generate a schema JSON object
-  // if `useBeta` is true, this will generate a schema for the Skill Builder Beta (containing utterances + custom slots)
-  this.schema = function(useBeta) {
-    if (useBeta) {
-      return betaSchema();
-    }
+  this.schemas = {
+    intent: function() {
+      var schema = {
+          "intents": []
+        },
+        intentName, intent, key;
+      for (intentName in self.intents) {
+        intent = self.intents[intentName];
+        var intentSchema = {
+          "intent": intent.name
+        };
+        if (intent.slots && Object.keys(intent.slots).length > 0) {
+          intentSchema["slots"] = [];
+          for (key in intent.slots) {
+            intentSchema.slots.push({
+              "name": key,
+              "type": intent.slots[key]
+            });
+          }
+        }
+        schema.intents.push(intentSchema);
+      }
+      return JSON.stringify(schema, null, 3);
+    },
 
-    var schema = {
-        "intents": []
-      },
-      intentName, intent, key;
-    for (intentName in self.intents) {
-      intent = self.intents[intentName];
-      var intentSchema = {
-        "intent": intent.name
-      };
-      if (intent.slots && Object.keys(intent.slots).length > 0) {
-        intentSchema["slots"] = [];
-        for (key in intent.slots) {
-          intentSchema.slots.push({
-            "name": key,
-            "type": intent.slots[key]
+    skillBuilder: function() {
+      var schema = {
+          "intents": []
+        },
+        intentName, intent, key;
+      for (intentName in self.intents) {
+        intent = self.intents[intentName];
+        var intentSchema = {
+          "name": intent.name,
+          "samples": []
+        };
+        if (intent.utterances && intent.utterances.length > 0) {
+          intent.utterances.forEach(function(sample) {
+            var list = AlexaUtterances(sample,
+              intent.slots,
+              self.dictionary,
+              self.exhaustiveUtterances);
+            list.forEach(function(utterance) {
+              intentSchema.samples.push(utterance);
+            });
           });
         }
+        if (intent.slots && Object.keys(intent.slots).length > 0) {
+          intentSchema["slots"] = [];
+          for (key in intent.slots) {
+            //  It's unclear whether `samples` is actually used for slots,
+            // but the interaction model will not build without an (empty) array
+            intentSchema.slots.push({
+              "name": key,
+              "type": intent.slots[key],
+              "samples": []
+            });
+          }
+        }
+        schema.intents.push(intentSchema);
       }
-      schema.intents.push(intentSchema);
+      return JSON.stringify(schema, null, 3);
     }
-    return JSON.stringify(schema, null, 3);
   };
 
-  var betaSchema = function() {
-    var schema = {
-        "intents": []
-      },
-      intentName, intent, key;
-    for (intentName in self.intents) {
-      intent = self.intents[intentName];
-      var intentSchema = {
-        "name": intent.name,
-        "samples": []
-      };
-      if (intent.utterances && intent.utterances.length > 0) {
-        intent.utterances.forEach(function(sample) {
-          var list = AlexaUtterances(sample,
-            intent.slots,
-            self.dictionary,
-            self.exhaustiveUtterances);
-          list.forEach(function(utterance) {
-            intentSchema.samples.push(utterance);
-          });
-        });
-      }
-      if (intent.slots && Object.keys(intent.slots).length > 0) {
-        intentSchema["slots"] = [];
-        for (key in intent.slots) {
-          //  It's unclear whether `samples` is actually used for slots, 
-          // but the interaction model will not build without an (empty) array
-          intentSchema.slots.push({
-            "name": key,
-            "type": intent.slots[key],
-            "samples": []
-          });
-        }
-      }
-      schema.intents.push(intentSchema);
-    }
-    return JSON.stringify(schema, null, 3);
+  // extract the schema and generate a schema JSON object
+  this.schema = function() {
+    return this.schemas.intent();
   };
 
   // generate a list of sample utterances
@@ -696,7 +697,6 @@ alexa.app = function(name) {
   // @param string options.endpoint the path to attach the router to (e.g., passing 'mine' attaches to '/mine')
   // @param bool options.checkCert when true, applies Alexa certificate checking (default true)
   // @param bool options.debug when true, sets up the route to handle GET requests (default false)
-  // @param bool options.betaSchema when true, Express debug requests will use the new Skill Builder Beta schema
   // @param function options.preRequest function to execute before every POST
   // @param function options.postRequest function to execute after every POST
   // @throws Error when router or expressApp options are not specified
@@ -722,14 +722,17 @@ alexa.app = function(name) {
 
     if (options.debug) {
       target.get(endpoint, function(req, res) {
+        var schemaName = req.query['schemaType'] || 'intent';
+        var schema = self.schemas[schemaName] || function() {};
+
         if (typeof req.query['schema'] != "undefined") {
-          res.set('Content-Type', 'text/plain').send(self.schema(options.betaSchema));
+          res.set('Content-Type', 'text/plain').send(schema());
         } else if (typeof req.query['utterances'] != "undefined") {
           res.set('Content-Type', 'text/plain').send(self.utterances());
         } else {
           res.render("test", {
             "app": self,
-            "schema": self.schema(options.betaSchema),
+            "schema": schema(),
             "utterances": self.utterances()
           });
         }

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -16,278 +16,331 @@ describe("Alexa", function() {
     });
 
     describe("#schema", function() {
-      describe("when the beta flag is false", function() {
-        describe("with a minimum intent", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent");
-          });
+      beforeEach(function() {
+        testApp.intent("AMAZON.PauseIntent");
 
-          it("contains no slots", function() {
-            var subject = JSON.parse(testApp.schema());
-            expect(subject).to.eql({
-              "intents": [{
-                "intent": "AMAZON.PauseIntent"
-              }]
-            });
+        testApp.intent("testIntentTwo", {
+          "slots": {
+            "MyCustomSlotType": "CUSTOMTYPE",
+            "Tubular": "AMAZON.LITERAL",
+            "Radical": "AMAZON.US_STATE"
+          }
+        });
+
+        testApp.intent("testIntent", {
+          "slots": {
+            "AirportCode": "FAACODES",
+            "Awesome": "AMAZON.DATE",
+            "Tubular": "AMAZON.LITERAL"
+          },
+        });
+      });
+
+      it("calls the intent schema as the default", function() {
+        var subject = JSON.parse(testApp.schema());
+        expect(subject).to.eql({
+          "intents": [{
+            "intent": "AMAZON.PauseIntent",
+          }, {
+            "intent": "testIntentTwo",
+            "slots": [{
+              "name": "MyCustomSlotType",
+              "type": "CUSTOMTYPE"
+            }, {
+              "name": "Tubular",
+              "type": "AMAZON.LITERAL"
+            }, {
+              "name": "Radical",
+              "type": "AMAZON.US_STATE"
+            }]
+          }, {
+            "intent": "testIntent",
+            "slots": [{
+              "name": "AirportCode",
+              "type": "FAACODES"
+            }, {
+              "name": "Awesome",
+              "type": "AMAZON.DATE"
+            }, {
+              "name": "Tubular",
+              "type": "AMAZON.LITERAL"
+            }]
+          }]
+        });
+      });
+    });
+
+    describe("#schemas.intent", function() {
+      describe("with a minimum intent", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+        });
+
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.intent());
+          expect(subject).to.eql({
+            "intents": [{
+              "intent": "AMAZON.PauseIntent"
+            }]
+          });
+        });
+      });
+
+      describe("with empty slots", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent", {
+            "slots": {}
           });
         });
 
-        describe("with empty slots", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent", {
-              "slots": {}
-            });
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.intent());
+          expect(subject).to.eql({
+            "intents": [{
+              "intent": "AMAZON.PauseIntent"
+            }]
           });
+        });
+      });
 
-          it("contains no slots", function() {
-            var subject = JSON.parse(testApp.schema());
-            expect(subject).to.eql({
-              "intents": [{
-                "intent": "AMAZON.PauseIntent"
-              }]
-            });
+      describe("with a slot", function() {
+        beforeEach(function() {
+          testApp.intent("testIntent", {
+            "slots": {
+              "MyCustomSlotType": "CUSTOMTYPE",
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE",
+            },
           });
         });
 
-        describe("with a slot", function() {
-          beforeEach(function() {
-            testApp.intent("testIntent", {
-              "slots": {
-                "MyCustomSlotType": "CUSTOMTYPE",
-                "Tubular": "AMAZON.LITERAL",
-                "Radical": "AMAZON.US_STATE",
-              },
-            });
-          });
-
-          it("includes slots", function() {
-            var subject = JSON.parse(testApp.schema());
-            expect(subject).to.eql({
-              "intents": [{
-                "intent": "testIntent",
-                "slots": [{
-                  "name": "MyCustomSlotType",
-                  "type": "CUSTOMTYPE"
-                }, {
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL"
-                }, {
-                  "name": "Radical",
-                  "type": "AMAZON.US_STATE"
-                }]
-              }]
-            });
-          });
-        });
-
-        describe("with multiple intents", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent");
-
-            testApp.intent("testIntentTwo", {
-              "slots": {
-                "MyCustomSlotType": "CUSTOMTYPE",
-                "Tubular": "AMAZON.LITERAL",
-                "Radical": "AMAZON.US_STATE"
-              }
-            });
-
-            testApp.intent("testIntent", {
-              "slots": {
-                "AirportCode": "FAACODES",
-                "Awesome": "AMAZON.DATE",
-                "Tubular": "AMAZON.LITERAL"
-              },
-            });
-          });
-
-          it("generates the expected schema", function() {
-            var subject = JSON.parse(testApp.schema());
-            expect(subject).to.eql({
-              "intents": [{
-                "intent": "AMAZON.PauseIntent",
+        it("includes slots", function() {
+          var subject = JSON.parse(testApp.schemas.intent());
+          expect(subject).to.eql({
+            "intents": [{
+              "intent": "testIntent",
+              "slots": [{
+                "name": "MyCustomSlotType",
+                "type": "CUSTOMTYPE"
               }, {
-                "intent": "testIntentTwo",
-                "slots": [{
-                  "name": "MyCustomSlotType",
-                  "type": "CUSTOMTYPE"
-                }, {
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL"
-                }, {
-                  "name": "Radical",
-                  "type": "AMAZON.US_STATE"
-                }]
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL"
               }, {
-                "intent": "testIntent",
-                "slots": [{
-                  "name": "AirportCode",
-                  "type": "FAACODES"
-                }, {
-                  "name": "Awesome",
-                  "type": "AMAZON.DATE"
-                }, {
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL"
-                }]
+                "name": "Radical",
+                "type": "AMAZON.US_STATE"
               }]
-            });
+            }]
+          });
+        });
+      });
+
+      describe("with multiple intents", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+
+          testApp.intent("testIntentTwo", {
+            "slots": {
+              "MyCustomSlotType": "CUSTOMTYPE",
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE"
+            }
+          });
+
+          testApp.intent("testIntent", {
+            "slots": {
+              "AirportCode": "FAACODES",
+              "Awesome": "AMAZON.DATE",
+              "Tubular": "AMAZON.LITERAL"
+            },
           });
         });
 
-      });   
-
-      describe("when the beta flag is true", function() {
-        describe("with a minimum intent", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent");
+        it("generates the expected schema", function() {
+          var subject = JSON.parse(testApp.schemas.intent());
+          expect(subject).to.eql({
+            "intents": [{
+              "intent": "AMAZON.PauseIntent",
+            }, {
+              "intent": "testIntentTwo",
+              "slots": [{
+                "name": "MyCustomSlotType",
+                "type": "CUSTOMTYPE"
+              }, {
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL"
+              }, {
+                "name": "Radical",
+                "type": "AMAZON.US_STATE"
+              }]
+            }, {
+              "intent": "testIntent",
+              "slots": [{
+                "name": "AirportCode",
+                "type": "FAACODES"
+              }, {
+                "name": "Awesome",
+                "type": "AMAZON.DATE"
+              }, {
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL"
+              }]
+            }]
           });
+        });
+      });
 
-          it("contains no slots", function() {
-            var subject = JSON.parse(testApp.schema(true));
-            expect(subject).to.eql({
-              "intents": [{
-                "name": "AMAZON.PauseIntent",
+    });
+
+    describe("#schemas.skillBuilder", function() {
+      describe("with a minimum intent", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+        });
+
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [{
+              "name": "AMAZON.PauseIntent",
+              "samples": []
+            }]
+          });
+        });
+      });
+
+      describe("with empty slots", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent", {
+            "slots": {}
+          });
+        });
+
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [{
+              "name": "AMAZON.PauseIntent",
+              "samples": []
+            }]
+          });
+        });
+      });
+
+      describe("with a slot", function() {
+        beforeEach(function() {
+          testApp.intent("testIntent", {
+            "slots": {
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE"
+            },
+          });
+        });
+
+        it("includes slots", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [{
+              "name": "testIntent",
+              "samples": [],
+              "slots": [{
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL",
+                "samples": []
+              }, {
+                "name": "Radical",
+                "type": "AMAZON.US_STATE",
                 "samples": []
               }]
-            });
+            }]
+          });
+        });
+      });
+
+      describe("with simple utterances", function() {
+        beforeEach(function() {
+          testApp.intent("testIntent", {
+            "utterances": ["turn on the thermostat", "kill all humans"]
           });
         });
 
-        describe("with empty slots", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent", {
-              "slots": {}
-            });
+        it("contains utterances", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [{
+              "name": "testIntent",
+              "samples": [
+                "turn on the thermostat",
+                "kill all humans"
+              ]
+            }]
+          });
+        });
+      });
+
+      describe("with multiple intents", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+
+          testApp.intent("testIntentTwo", {
+            "slots": {
+              "MyCustomSlotType": "CUSTOMTYPE",
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE"
+            },
           });
 
-          it("contains no slots", function() {
-            var subject = JSON.parse(testApp.schema(true));
-            expect(subject).to.eql({
-              "intents": [{
-                "name": "AMAZON.PauseIntent",
+          testApp.intent("testIntent", {
+            "slots": {
+              "AirportCode": "FAACODES",
+              "Awesome": "AMAZON.DATE",
+              "Tubular": "AMAZON.LITERAL"
+            },
+          });
+        });
+
+        it("generates the expected schema", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [{
+              "name": "AMAZON.PauseIntent",
+              "samples": []
+            }, {
+              "name": "testIntentTwo",
+              "samples": [],
+              "slots": [{
+                "name": "MyCustomSlotType",
+                "type": "CUSTOMTYPE",
+                "samples": []
+              }, {
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL",
+                "samples": []
+              }, {
+                "name": "Radical",
+                "type": "AMAZON.US_STATE",
                 "samples": []
               }]
-            });
-          });
-        });
-
-        describe("with a slot", function() {
-          beforeEach(function() {
-            testApp.intent("testIntent", {
-              "slots": {
-                "Tubular": "AMAZON.LITERAL",
-                "Radical": "AMAZON.US_STATE"
-              },
-            });
-          });
-
-          it("includes slots", function() {
-            var subject = JSON.parse(testApp.schema(true));
-            expect(subject).to.eql({
-              "intents": [{
-                "name": "testIntent",
-                "samples": [],
-                "slots": [{
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL",
-                  "samples": []                  
-                }, {
-                  "name": "Radical",
-                  "type": "AMAZON.US_STATE",
-                  "samples": []                  
-                }]
-              }]
-            });
-          });
-        });
-
-        describe("with simple utterances", function() {
-          beforeEach(function() {
-            testApp.intent("testIntent", {
-              "utterances": ["turn on the thermostat", "kill all humans"]
-            });
-          });
-
-          it("contains utterances", function() {
-            var subject = JSON.parse(testApp.schema(true));
-            expect(subject).to.eql({
-              "intents": [{
-                "name": "testIntent",
-                "samples": [
-                  "turn on the thermostat", 
-                  "kill all humans"
-                ]
-              }]
-            });
-          });
-        });
-
-        describe("with multiple intents", function() {
-          beforeEach(function() {
-            testApp.intent("AMAZON.PauseIntent");
-
-            testApp.intent("testIntentTwo", {
-              "slots": {
-                "MyCustomSlotType": "CUSTOMTYPE",
-                "Tubular": "AMAZON.LITERAL",
-                "Radical": "AMAZON.US_STATE"
-              },
-            });
-
-            testApp.intent("testIntent", {
-              "slots": {
-                "AirportCode": "FAACODES",
-                "Awesome": "AMAZON.DATE",
-                "Tubular": "AMAZON.LITERAL"
-              },
-            });
-          });
-
-          it("generates the expected schema", function() {
-            var subject = JSON.parse(testApp.schema(true));
-            expect(subject).to.eql({
-              "intents": [{
-                "name": "AMAZON.PauseIntent",
-                "samples": []                
+            }, {
+              "name": "testIntent",
+              "samples": [],
+              "slots": [{
+                "name": "AirportCode",
+                "type": "FAACODES",
+                "samples": []
               }, {
-                "name": "testIntentTwo",
-                "samples": [],
-                "slots": [{
-                  "name": "MyCustomSlotType",
-                  "type": "CUSTOMTYPE",
-                  "samples": []                  
-                }, {
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL",
-                  "samples": []                  
-                }, {
-                  "name": "Radical",
-                  "type": "AMAZON.US_STATE",
-                  "samples": []                  
-                }]
+                "name": "Awesome",
+                "type": "AMAZON.DATE",
+                "samples": []
               }, {
-                "name": "testIntent",
-                "samples": [],                
-                "slots": [{
-                  "name": "AirportCode",
-                  "type": "FAACODES",
-                  "samples": []                  
-                }, {
-                  "name": "Awesome",
-                  "type": "AMAZON.DATE",
-                  "samples": []                  
-                }, {
-                  "name": "Tubular",
-                  "type": "AMAZON.LITERAL",
-                  "samples": []                  
-                }]
+                "name": "Tubular",
+                "type": "AMAZON.LITERAL",
+                "samples": []
               }]
-            });
+            }]
           });
         });
+      });
 
-      });     
     });
   });
 });

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -2,7 +2,6 @@
 "use strict";
 var chai = require("chai");
 var chaiAsPromised = require("chai-as-promised");
-var mockHelper = require("./helpers/mock_helper");
 chai.use(chaiAsPromised);
 var expect = chai.expect;
 chai.config.includeStack = true;
@@ -17,123 +16,278 @@ describe("Alexa", function() {
     });
 
     describe("#schema", function() {
-      describe("with a minimum intent", function() {
-        beforeEach(function() {
-          testApp.intent("AMAZON.PauseIntent");
-        });
-
-        it("contains no slots", function() {
-          var subject = JSON.parse(testApp.schema());
-          expect(subject).to.eql({
-            "intents": [{
-              "intent": "AMAZON.PauseIntent"
-            }]
+      describe("when the beta flag is false", function() {
+        describe("with a minimum intent", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent");
           });
-        });
-      });
 
-      describe("with empty slots", function() {
-        beforeEach(function() {
-          testApp.intent("AMAZON.PauseIntent", {
-            "slots": {}
-          });
-        });
-
-        it("contains no slots", function() {
-          var subject = JSON.parse(testApp.schema());
-          expect(subject).to.eql({
-            "intents": [{
-              "intent": "AMAZON.PauseIntent"
-            }]
-          });
-        });
-      });
-
-      describe("with a slot", function() {
-        beforeEach(function() {
-          testApp.intent("testIntent", {
-            "slots": {
-              "MyCustomSlotType": "CUSTOMTYPE",
-              "Tubular": "AMAZON.LITERAL",
-              "Radical": "AMAZON.US_STATE",
-            },
-          });
-        });
-
-        it("includes slots", function() {
-          var subject = JSON.parse(testApp.schema());
-          expect(subject).to.eql({
-            "intents": [{
-              "intent": "testIntent",
-              "slots": [{
-                "name": "MyCustomSlotType",
-                "type": "CUSTOMTYPE"
-              }, {
-                "name": "Tubular",
-                "type": "AMAZON.LITERAL"
-              }, {
-                "name": "Radical",
-                "type": "AMAZON.US_STATE"
+          it("contains no slots", function() {
+            var subject = JSON.parse(testApp.schema());
+            expect(subject).to.eql({
+              "intents": [{
+                "intent": "AMAZON.PauseIntent"
               }]
-            }]
-          });
-        });
-      });
-
-      describe("with multiple intents", function() {
-        beforeEach(function() {
-          testApp.intent("AMAZON.PauseIntent");
-
-          testApp.intent("testIntentTwo", {
-            "slots": {
-              "MyCustomSlotType": "CUSTOMTYPE",
-              "Tubular": "AMAZON.LITERAL",
-              "Radical": "AMAZON.US_STATE",
-            },
-          });
-
-          testApp.intent("testIntent", {
-            "slots": {
-              "AirportCode": "FAACODES",
-              "Awesome": "AMAZON.DATE",
-              "Tubular": "AMAZON.LITERAL"
-            },
+            });
           });
         });
 
-        it("generates the expected schema", function() {
-          var subject = JSON.parse(testApp.schema());
-          expect(subject).to.eql({
-            "intents": [{
-              "intent": "AMAZON.PauseIntent",
-            }, {
-              "intent": "testIntentTwo",
-              "slots": [{
-                "name": "MyCustomSlotType",
-                "type": "CUSTOMTYPE"
-              }, {
-                "name": "Tubular",
-                "type": "AMAZON.LITERAL"
-              }, {
-                "name": "Radical",
-                "type": "AMAZON.US_STATE"
+        describe("with empty slots", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent", {
+              "slots": {}
+            });
+          });
+
+          it("contains no slots", function() {
+            var subject = JSON.parse(testApp.schema());
+            expect(subject).to.eql({
+              "intents": [{
+                "intent": "AMAZON.PauseIntent"
               }]
-            }, {
-              "intent": "testIntent",
-              "slots": [{
-                "name": "AirportCode",
-                "type": "FAACODES"
-              }, {
-                "name": "Awesome",
-                "type": "AMAZON.DATE"
-              }, {
-                "name": "Tubular",
-                "type": "AMAZON.LITERAL"
-              }]
-            }]
+            });
           });
         });
-      });
+
+        describe("with a slot", function() {
+          beforeEach(function() {
+            testApp.intent("testIntent", {
+              "slots": {
+                "MyCustomSlotType": "CUSTOMTYPE",
+                "Tubular": "AMAZON.LITERAL",
+                "Radical": "AMAZON.US_STATE",
+              },
+            });
+          });
+
+          it("includes slots", function() {
+            var subject = JSON.parse(testApp.schema());
+            expect(subject).to.eql({
+              "intents": [{
+                "intent": "testIntent",
+                "slots": [{
+                  "name": "MyCustomSlotType",
+                  "type": "CUSTOMTYPE"
+                }, {
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL"
+                }, {
+                  "name": "Radical",
+                  "type": "AMAZON.US_STATE"
+                }]
+              }]
+            });
+          });
+        });
+
+        describe("with multiple intents", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent");
+
+            testApp.intent("testIntentTwo", {
+              "slots": {
+                "MyCustomSlotType": "CUSTOMTYPE",
+                "Tubular": "AMAZON.LITERAL",
+                "Radical": "AMAZON.US_STATE"
+              }
+            });
+
+            testApp.intent("testIntent", {
+              "slots": {
+                "AirportCode": "FAACODES",
+                "Awesome": "AMAZON.DATE",
+                "Tubular": "AMAZON.LITERAL"
+              },
+            });
+          });
+
+          it("generates the expected schema", function() {
+            var subject = JSON.parse(testApp.schema());
+            expect(subject).to.eql({
+              "intents": [{
+                "intent": "AMAZON.PauseIntent",
+              }, {
+                "intent": "testIntentTwo",
+                "slots": [{
+                  "name": "MyCustomSlotType",
+                  "type": "CUSTOMTYPE"
+                }, {
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL"
+                }, {
+                  "name": "Radical",
+                  "type": "AMAZON.US_STATE"
+                }]
+              }, {
+                "intent": "testIntent",
+                "slots": [{
+                  "name": "AirportCode",
+                  "type": "FAACODES"
+                }, {
+                  "name": "Awesome",
+                  "type": "AMAZON.DATE"
+                }, {
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL"
+                }]
+              }]
+            });
+          });
+        });
+
+      });   
+
+      describe("when the beta flag is true", function() {
+        describe("with a minimum intent", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent");
+          });
+
+          it("contains no slots", function() {
+            var subject = JSON.parse(testApp.schema(true));
+            expect(subject).to.eql({
+              "intents": [{
+                "name": "AMAZON.PauseIntent",
+                "samples": []
+              }]
+            });
+          });
+        });
+
+        describe("with empty slots", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent", {
+              "slots": {}
+            });
+          });
+
+          it("contains no slots", function() {
+            var subject = JSON.parse(testApp.schema(true));
+            expect(subject).to.eql({
+              "intents": [{
+                "name": "AMAZON.PauseIntent",
+                "samples": []
+              }]
+            });
+          });
+        });
+
+        describe("with a slot", function() {
+          beforeEach(function() {
+            testApp.intent("testIntent", {
+              "slots": {
+                "Tubular": "AMAZON.LITERAL",
+                "Radical": "AMAZON.US_STATE"
+              },
+            });
+          });
+
+          it("includes slots", function() {
+            var subject = JSON.parse(testApp.schema(true));
+            expect(subject).to.eql({
+              "intents": [{
+                "name": "testIntent",
+                "samples": [],
+                "slots": [{
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL",
+                  "samples": []                  
+                }, {
+                  "name": "Radical",
+                  "type": "AMAZON.US_STATE",
+                  "samples": []                  
+                }]
+              }]
+            });
+          });
+        });
+
+        describe("with simple utterances", function() {
+          beforeEach(function() {
+            testApp.intent("testIntent", {
+              "utterances": ["turn on the thermostat", "kill all humans"]
+            });
+          });
+
+          it("contains utterances", function() {
+            var subject = JSON.parse(testApp.schema(true));
+            expect(subject).to.eql({
+              "intents": [{
+                "name": "testIntent",
+                "samples": [
+                  "turn on the thermostat", 
+                  "kill all humans"
+                ]
+              }]
+            });
+          });
+        });
+
+        describe("with multiple intents", function() {
+          beforeEach(function() {
+            testApp.intent("AMAZON.PauseIntent");
+
+            testApp.intent("testIntentTwo", {
+              "slots": {
+                "MyCustomSlotType": "CUSTOMTYPE",
+                "Tubular": "AMAZON.LITERAL",
+                "Radical": "AMAZON.US_STATE"
+              },
+            });
+
+            testApp.intent("testIntent", {
+              "slots": {
+                "AirportCode": "FAACODES",
+                "Awesome": "AMAZON.DATE",
+                "Tubular": "AMAZON.LITERAL"
+              },
+            });
+          });
+
+          it("generates the expected schema", function() {
+            var subject = JSON.parse(testApp.schema(true));
+            expect(subject).to.eql({
+              "intents": [{
+                "name": "AMAZON.PauseIntent",
+                "samples": []                
+              }, {
+                "name": "testIntentTwo",
+                "samples": [],
+                "slots": [{
+                  "name": "MyCustomSlotType",
+                  "type": "CUSTOMTYPE",
+                  "samples": []                  
+                }, {
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL",
+                  "samples": []                  
+                }, {
+                  "name": "Radical",
+                  "type": "AMAZON.US_STATE",
+                  "samples": []                  
+                }]
+              }, {
+                "name": "testIntent",
+                "samples": [],                
+                "slots": [{
+                  "name": "AirportCode",
+                  "type": "FAACODES",
+                  "samples": []                  
+                }, {
+                  "name": "Awesome",
+                  "type": "AMAZON.DATE",
+                  "samples": []                  
+                }, {
+                  "name": "Tubular",
+                  "type": "AMAZON.LITERAL",
+                  "samples": []                  
+                }]
+              }]
+            });
+          });
+        });
+
+      });     
     });
   });
 });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -107,22 +107,43 @@ describe("Alexa", function() {
         });
       });
 
-      it("dumps debug schema", function() {
-        return request(testServer)
-          .get('/testApp')
-          .expect(200).then(function(response) {
-            expect(response.text).to.startWith('{"name":"testApp"')
-          });
-      });
+      context("when no schema type is sent", function() {
+        it("dumps default debug schema", function() {
+          return request(testServer)
+            .get('/testApp')
+            .expect(200).then(function(response) {
+              expect(response.text).to.startWith('{"name":"testApp"')
+            });
+        });
 
-      it("returns debug schema", function() {
-        return request(testServer)
-          .get('/testApp?schema')
-          .expect(200).then(function(response) {
-            expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
-            expect(response.text).to.eq(testApp.schema());
-          });
-      });
+        it("returns default debug schema", function() {
+          return request(testServer)
+            .get('/testApp?schema')
+            .expect(200).then(function(response) {
+              expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+              expect(response.text).to.eq(testApp.schema());
+            });
+        });
+      })
+
+      context("when the skill builder schema type is sent", function() {
+        it("dumps skill builder debug schema", function() {
+          return request(testServer)
+            .get('/testApp?schemaType=skillBuilder')
+            .expect(200).then(function(response) {
+              expect(response.text).to.startWith('{"name":"testApp"')
+            });
+        });
+
+        it("returns default debug schema", function() {
+          return request(testServer)
+            .get('/testApp?schema&schemaType=skillBuilder')
+            .expect(200).then(function(response) {
+              expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+              expect(response.text).to.eq(testApp.schemas.skillBuilder());
+            });
+        });
+      })
 
       it("returns debug utterances", function() {
         return request(testServer)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,10 +63,20 @@ export class app {
 
   request: (requestJSON: alexa.Request) => void;
 
-  /** Extracts the schema and generates a schema JSON object
-   * @param boolean useBeta If true, will return the new Skill Builder Beta schema
+  /** @deprecated It's recommended you directly call `app.schema.*` instead
+   * Extracts the schema and generates a schema JSON object
+   * This is equivalent to calling `app.schemas.intent()`
    */
-  schema: (useBeta: boolean) => string;
+  schema: () => string;
+
+  /** Functions to generate schema JSON objects in Amazon's various formats */
+  schemas: {
+    /** Generates a schema in the old default intent format */
+    intent(): string;
+
+    /** Generates a schema in the new Skill Builder beta format */
+    skillBuilder(): string;
+  };
 
   /** Generates a list of sample utterances */
   utterances: () => string;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -63,8 +63,10 @@ export class app {
 
   request: (requestJSON: alexa.Request) => void;
 
-  /** Extracts the schema and generates a schema JSON object */
-  schema: () => string;
+  /** Extracts the schema and generates a schema JSON object
+   * @param boolean useBeta If true, will return the new Skill Builder Beta schema
+   */
+  schema: (useBeta: boolean) => string;
 
   /** Generates a list of sample utterances */
   utterances: () => string;
@@ -82,6 +84,7 @@ export class app {
    * @param string options.endpoint the path to attach the router to (e.g., passing 'mine' attaches to '/mine')
    * @param bool options.checkCert when true, applies Alexa certificate checking (default true)
    * @param bool options.debug when true, sets up the route to handle GET requests (default false)
+   * @param bool options.betaSchema when true, Express debug requests will use the new Skill Builder Beta schema
    * @param function options.preRequest function to execute before every POST
    * @param function options.postRequest function to execute after every POST
    * @throws Error when router or expressApp options are not specified

--- a/types/test.ts
+++ b/types/test.ts
@@ -26,5 +26,8 @@ app.intent('intentName', {
     .shouldEndSession(false, "Reprompt!");
 });
 
+const intentSchema: string = app.schemas.intent();
+const skillBuilderSchema: string = app.schemas.skillBuilder();
+
 export const new_handler = app.handler;
 export const legacy_handler = app.lambda();


### PR DESCRIPTION
Currently, people using this library to generate intent schemas and sample utterance lists cannot use the [Skill Builder Beta](https://developer.amazon.com/blogs/alexa/post/02d828b6-3144-46ea-9b4c-5ed2cbfadb9c/announcing-new-alexa-skill-builder-beta-a-tool-for-creating-skills), as the new schema JSON format is not compatible with the format being generated by `app.schema()`.

This adds an optional boolean argument to `app.schema()` that, if `true`, generates a schema that's readable by the new beta tool, as well as a `betaSchema` option to `app.express()` that gets threaded through for HTTP requests that result in a schema being generated/output.

For now, all this means is a few key names are different, there are some empty arrays, and each intent now includes its sample utterances inline. More importantly, this is necessary groundwork to eventually add library support for various new features afforded by the new tool, such as intent confirmation (https://github.com/alexa-js/alexa-app/issues/255), multi-turn dialogs, custom slot synonyms, and being able to declaratively specify custom slots in the schema itself  (https://github.com/alexa-js/alexa-app/issues/222).

Implementation wise, I intentionally kept this separate from the existing schema generation code — both the tests and the production code are just copy/pasted and modified versions of the existing schema code. We'll eventually want to make the new schema the default one, and perhaps even deprecate the old one, which suggests keeping them separate will make that easier. 

Sometime relatively soon I should have a corresponding PR in http://github.com/alexa-js/alexa-app-server that adds a configuration flag to output this in its default HTML template, but that shouldn't be a blocker to merging this in.