### PR TITLE
Update request session typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.1.1 (Next)
 
+* [#271](https://github.com/alexa-js/alexa-app/pull/271): Update request typing - [@jontg](https://github.com/jontg).
 * Your contribution here
 
 ### 4.1.0 (August 12, 2017)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -115,7 +115,7 @@ export class request {
   hasSession: () => boolean;
 
   /** Returns the session object */
-  getSession: () => session;
+  getSession: () => alexa.Session;
 
   /** Returns the request context */
   context?: alexa.Context;

--- a/types/test.ts
+++ b/types/test.ts
@@ -2,7 +2,16 @@ import * as alexa from 'alexa-app';
 
 const app = new alexa.app('app-name');
 
-app.pre = (request, response, type) => {};
+app.pre = (request, response, type) => {
+  if (request.applicationId !== undefined) {
+    // As documented in https://github.com/alexa-js/alexa-app#session
+    throw new Error('Invalid Application ID');
+  }
+  if (request.hasSession() && request.getSession().application.applicationId !== undefined) {
+    // As documented in https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/alexa-skills-kit-interface-reference#session-object
+    throw new Error('Invalid Application ID');
+  }
+};
 app.post = (request, response, type) => {};
 
 app.launch((request, response) => {});


### PR DESCRIPTION
I'm reasonably certain the session in our `request` object is an `alexa.Session`...  Running locally I get all sorts of type warnings if I do what I believe is right
```bash
ERROR in ./handler.ts
(11,31): error TS2339: Property 'application' does not exist on type 'session'.
```

But on the other hand, if I try to follow the type definitions, I get
```bash
  Error --------------------------------------------------

  Unhandled exception: Cannot read property 'applicationId' of undefined.
```

On the *third* hand, if we circumvent the type definitions via (for example) the following code snippet, everything works hunky dory
```javascript
app.pre = (request, response, type) => {
  if (process.env.ALEXA_APP_ID !== undefined && !request.hasSession()) {
    // Ugly hack to work around Session type not being found properly
    const session : any = request.getSession();
    if ( session.application.applicationId != process.env.ALEXA_APP_ID) {
      console.log("Saw an unauthorized request from '%j'", request);
      throw "Invalid applicationId"; // Fail ungracefully
    }
  }
};
```