### PR TITLE
Add support for custom slot types 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#268](https://github.com/alexa-js/alexa-app/pull/268): Add support for outputting new Skill Builder schema - [@lazerwalker](https://github.com/lazerwalker).
 * [#273](https://github.com/alexa-js/alexa-app/pull/273): Correct inconsistent slots API documentation and interface definitions - [@padraigkitterick](https://github.com/padraigkitterick).
 * [#274](https://github.com/alexa-js/alexa-app/pull/274): Correct inconsistent interface definitions for optional ExpressOptions properties - [@lazerwalker](https://github.com/lazerwalker).
+* [#275](https://github.com/alexa-js/alexa-app/pull/275): Add support for custom slot types (for Skill Builder schema output) - [@lazerwalker](https://github.com/lazerwalker).
 * Your contribution here
 
 ### 4.1.0 (August 12, 2017)

--- a/README.md
+++ b/README.md
@@ -564,6 +564,24 @@ sampleIntent     airport status for {CustomSlotName}
 
 Note that the "CustomSlotType" type values must be specified in the Skill Interface's Interaction Model for the custom slot type to function correctly.
 
+#### custom slot type values
+
+If you have custom slot types, you can define your custom slot type values as well. Custom values can either be simple strings, or more full-fledged objects if you want to take advantage of Skill Builder features like synonyms.
+
+```javascript
+testApp.customSlot("animal", ["cat", "dog"]);
+```
+
+OR
+
+```javascript
+testApp.customSlot("animal", [{
+  value: "dog",
+  id: "canine",
+  synonyms: ["doggo", "pupper", "woofmeister"]
+}]);
+```
+
 #### utterances
 
 The utterances syntax allows you to generate many (hundreds or even thousands) of sample utterances using just a few samples that get auto-expanded.
@@ -628,8 +646,9 @@ WhatsMyColorIntent tell me what my favorite color is
 
 If you are using the Skill Builder Beta, the `schemas.skillBuilder()` function will generate a single schema JSON string
 that includes your intents with all of their utterances
+
 ```javascript
-app.schemas.intent() =>
+app.schemas.skillBuilder() =>
 
 {
   "intents": [{
@@ -645,7 +664,17 @@ app.schemas.intent() =>
       "type": "AMAZON.Color",
       "samples": []
     }]
-  }]
+  }],
+  "types": [{
+    "name": "MyCustomColor",
+    "values": [{
+		  "id": null,
+		  "name": {
+        "value": "aquamarine", 
+        "synonyms": ["aqua", "seafoam", "teal"]
+		  }
+    }]
+  }];
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -430,18 +430,27 @@ alexa.app = function(name) {
 
   this.customSlots = {};
   this.customSlot = function(slotName, values) {
-    values = values.map(function(value) {
+    self.customSlots[slotName] = [];
+    
+    values.forEach(function(value) {
+      var valueObj;
       if (typeof value === "string") {
-        return {
+        valueObj = {
           value: value,
           id: null,
           synonyms: []
         };
       } else {
-        return Object.assign({id: null, synonyms: []}, value);
+        if (!value.id) {
+          value.id = null;
+        }
+        if (!value.synonyms) {
+          value.synonyms = [];
+        }
+        valueObj = value;
       }
+      self.customSlots[slotName].push(valueObj);
     });
-    self.customSlots[slotName] = values;
   };
 
   this.audioPlayerEventHandlers = {};
@@ -663,21 +672,22 @@ alexa.app = function(name) {
       }
 
       for (var slotName in self.customSlots) {
+        var slotSchema = {
+          name: slotName,
+          values: []
+        };
+
         var values = self.customSlots[slotName];
-        var valueSchemas = values.map(function(value) {
-          return {
+        values.forEach(function(value) {
+          var valueSchema = {
             "id": value.id,
             "name": {
               "value": value.value,
               "synonyms": value.synonyms || []
             }
           }; 
+          slotSchema.values.push(valueSchema);
         });     
-
-        var slotSchema = {
-          name: slotName,
-          values: valueSchemas
-        };
 
         schema.types.push(slotSchema);
       }

--- a/index.js
+++ b/index.js
@@ -427,6 +427,23 @@ alexa.app = function(name) {
     }
     self.intents[intentName] = new alexa.intent(intentName, schema, func);
   };
+
+  this.customSlots = {};
+  this.customSlot = function(slotName, values) {
+    values = values.map(function(value) {
+      if (typeof value === "string") {
+        return {
+          value: value,
+          id: null,
+          synonyms: []
+        };
+      } else {
+        return value;
+      }
+    });
+    self.customSlots[slotName] = values;
+  };
+
   this.audioPlayerEventHandlers = {};
   this.audioPlayer = function(eventName, func) {
     self.audioPlayerEventHandlers[eventName] = {
@@ -609,7 +626,8 @@ alexa.app = function(name) {
 
     skillBuilder: function() {
       var schema = {
-          "intents": []
+          "intents": [],
+          "types": []
         },
         intentName, intent, key;
       for (intentName in self.intents) {
@@ -642,6 +660,26 @@ alexa.app = function(name) {
           }
         }
         schema.intents.push(intentSchema);
+      }
+
+      for (var slotName in self.customSlots) {
+        var values = self.customSlots[slotName];
+        var valueSchemas = values.map(function(value) {
+          return {
+            "id": value.id,
+            "name": {
+              "value": value.value,
+              "synonyms": value.synonyms || []
+            }
+          }; 
+        });     
+
+        var slotSchema = {
+          name: slotName,
+          values: valueSchemas
+        };
+
+        schema.types.push(slotSchema);
       }
       return JSON.stringify(schema, null, 3);
     }

--- a/index.js
+++ b/index.js
@@ -438,7 +438,7 @@ alexa.app = function(name) {
           synonyms: []
         };
       } else {
-        return value;
+        return Object.assign({id: null, synonyms: []}, value);
       }
     });
     self.customSlots[slotName] = values;

--- a/test/test_alexa_app_customslot.js
+++ b/test/test_alexa_app_customslot.js
@@ -1,0 +1,65 @@
+/*jshint expr: true*/
+"use strict";
+var chai = require("chai");
+var chaiAsPromised = require("chai-as-promised");
+var mockHelper = require("./helpers/mock_helper");
+chai.use(chaiAsPromised);
+var expect = chai.expect;
+chai.config.includeStack = true;
+
+describe("Alexa", function() {
+  var Alexa = require("../index");
+
+  describe("app", function() {
+    var testApp;
+    beforeEach(function() {
+      testApp = new Alexa.app("testApp");
+    });
+
+    context("#customslot", function() {
+      var slotValue = {
+        value: "dog",
+        synonyms: ["pupper, doggo"],
+        id: "dog"
+      };
+
+      context("with slot value objects", function() {
+        beforeEach(function() {
+          testApp.customSlot("animals", [slotValue]);
+        });
+
+        it("adds the slot value", function() {
+          expect(testApp.customSlots["animals"]).to.eql([slotValue]);
+        });
+      });
+
+      context("with strings", function() {
+        beforeEach(function() {
+          testApp.customSlot("animals", ["dog"]);
+        });
+
+        it("converts the string into a slot value", function() {
+          expect(testApp.customSlots["animals"]).to.eql([{
+            value: "dog",
+            synonyms: [],
+            id: null
+          }]);
+        });
+      });
+
+      context("with a mix of strings and objects", function() {  
+        beforeEach(function() {
+          testApp.customSlot("animals", ["dog", slotValue]);
+        });
+
+        it("assigns both properly", function() {
+          expect(testApp.customSlots["animals"]).to.eql([{
+            value: "dog",
+            synonyms: [],
+            id: null
+          }, slotValue]);
+        });
+      });
+    });
+  });
+});

--- a/test/test_alexa_app_customslot.js
+++ b/test/test_alexa_app_customslot.js
@@ -23,13 +23,27 @@ describe("Alexa", function() {
         id: "dog"
       };
 
-      context("with slot value objects", function() {
+      context("with a complete slot value object", function() {
         beforeEach(function() {
           testApp.customSlot("animals", [slotValue]);
         });
 
         it("adds the slot value", function() {
           expect(testApp.customSlots["animals"]).to.eql([slotValue]);
+        });
+      });
+
+      context("with an incomplete slot value object", function() {
+        beforeEach(function() {
+          testApp.customSlot("animals", [{value: "dog"}]);
+        });
+
+        it("adds the slot value with default params", function() {
+          expect(testApp.customSlots["animals"]).to.eql([{
+            value: "dog",
+            synonyms: [],
+            id: null
+          }]);
         });
       });
 

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -203,7 +203,8 @@ describe("Alexa", function() {
             "intents": [{
               "name": "AMAZON.PauseIntent",
               "samples": []
-            }]
+            }],
+            "types": []
           });
         });
       });
@@ -221,7 +222,8 @@ describe("Alexa", function() {
             "intents": [{
               "name": "AMAZON.PauseIntent",
               "samples": []
-            }]
+            }],
+            "types": []
           });
         });
       });
@@ -251,7 +253,8 @@ describe("Alexa", function() {
                 "type": "AMAZON.US_STATE",
                 "samples": []
               }]
-            }]
+            }],
+            "types": []
           });
         });
       });
@@ -272,7 +275,8 @@ describe("Alexa", function() {
                 "turn on the thermostat",
                 "kill all humans"
               ]
-            }]
+            }],
+            "types": []
           });
         });
       });
@@ -336,11 +340,113 @@ describe("Alexa", function() {
                 "type": "AMAZON.LITERAL",
                 "samples": []
               }]
-            }]
+            }],
+            "types": []
           });
         });
       });
 
+      describe("with a custom slot", function() {
+        beforeEach(function() {
+          testApp.customSlot("animal", [
+            "cat",
+            {
+              value: "dog",
+              id: "canine",
+              synonyms: ["doggo", "pupper", "woofmeister"]
+            }
+          ]);
+        });
+
+        it("includes custom slots", function() {
+          var subject = JSON.parse(testApp.schemas.skillBuilder());
+          expect(subject).to.eql({
+            "intents": [],
+            "types": [
+              {
+                "name": "animal",
+                "values": [
+                  {
+                    "id": null,
+                    "name": {
+                      "value": "cat",
+                      "synonyms": []
+                    }
+                  },
+                  {
+                    "id": "canine",
+                    "name": {
+                      "value": "dog", 
+                      "synonyms": ["doggo", "pupper", "woofmeister"]
+                    }
+                  }
+                ]
+              }
+            ]
+          });
+        });
+        describe("with multiple custom slots", function() {
+          beforeEach(function() {
+            testApp.customSlot("animal", [
+              "cat",
+              {
+                value: "dog",
+                id: "canine",
+                synonyms: ["doggo", "pupper", "woofmeister"]
+              }
+            ]);
+
+            testApp.customSlot("vegetable", ["carrot", "cucumber"]);
+          });
+  
+          it("includes all custom slots", function() {
+            var subject = JSON.parse(testApp.schemas.skillBuilder());
+            expect(subject).to.eql({
+              "intents": [],
+              "types": [
+                {
+                  "name": "animal",
+                  "values": [
+                    {
+                      "id": null,
+                      "name": {
+                        "value": "cat",
+                        "synonyms": []
+                      }
+                    },
+                    {
+                      "id": "canine",
+                      "name": {
+                        "value": "dog", 
+                        "synonyms": ["doggo", "pupper", "woofmeister"]
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "vegetable",
+                  "values": [
+                    {
+                      "id": null,
+                      "name": {
+                        "value": "carrot",
+                        "synonyms": []
+                      }
+                    },
+                    {
+                      "id": null,
+                      "name": {
+                        "value": "cucumber",
+                        "synonyms": []
+                      }
+                    }
+                  ]
+                }
+              ]
+            });
+          });
+        });
+      });
     });
   });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -50,6 +50,10 @@ export class app {
   dictionary: any;
 
   intents: {[name: string]: alexa.Intent};
+  intent: (intentName: string, schema: IntentSchema, handler: RequestHandler) => void;
+
+  customSlots: {[name: string]: CustomSlot}
+  customSlot: (name: string, values: (CustomSlot|string)[]) => void;
 
   // TODO
   audioPlayerEventHandlers: any;
@@ -101,8 +105,6 @@ export class app {
    * @returns this
    */
   express: (options: ExpressOptions) => void;
-
-  intent: (intentName: string, schema: IntentSchema, handler: RequestHandler) => void;
 }
 
 export class request {
@@ -306,4 +308,10 @@ export interface ExpressOptions {
 export interface IntentSchema {
   slots: any;
   utterances: string[];
+}
+
+export interface CustomSlot {
+  value: string;
+  synonyms: string[];
+  id: string|null;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -52,8 +52,8 @@ export class app {
   intents: {[name: string]: alexa.Intent};
   intent: (intentName: string, schema: IntentSchema, handler: RequestHandler) => void;
 
-  customSlots: {[name: string]: CustomSlot}
-  customSlot: (name: string, values: (CustomSlot|string)[]) => void;
+  customSlots: {[name: string]: CustomSlot};
+  customSlot: (name: string, values: Array<CustomSlot|string>) => void;
 
   // TODO
   audioPlayerEventHandlers: any;
@@ -312,6 +312,6 @@ export interface IntentSchema {
 
 export interface CustomSlot {
   value: string;
-  synonyms: string[];
-  id: string|null;
+  synonyms?: string[];
+  id?: string|null;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -306,8 +306,9 @@ export interface ExpressOptions {
 }
 
 export interface IntentSchema {
-  slots: any;
-  utterances: string[];
+  dialog?: object;
+  slots?: any;
+  utterances?: string[];
 }
 
 export interface CustomSlot {

--- a/types/test.ts
+++ b/types/test.ts
@@ -40,6 +40,12 @@ app.express({
   postRequest: (json: any, req: any, res: any) => {}
 });
 
+app.customSlot("myCustomSlot", ["a value", {
+  value: "another value",
+  synonyms: [],
+  id: null
+}])
+
 const intentSchema: string = app.schemas.intent();
 const skillBuilderSchema: string = app.schemas.skillBuilder();
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -17,6 +17,7 @@ app.post = (request, response, type) => {};
 app.launch((request, response) => {});
 
 app.intent('intentName', {
+  dialog: {type: "directive"},
   slots: {},
   utterances: ['do a thing']
 }, (request, response) => {
@@ -25,6 +26,8 @@ app.intent('intentName', {
     .card({type: "Simple"})
     .shouldEndSession(false, "Reprompt!");
 });
+
+app.intent('emptySchema', {}, (request, response) => {});
 
 app.express({
   expressApp: {}
@@ -44,7 +47,7 @@ app.customSlot("myCustomSlot", ["a value", {
   value: "another value",
   synonyms: [],
   id: null
-}])
+}]);
 
 const intentSchema: string = app.schemas.intent();
 const skillBuilderSchema: string = app.schemas.skillBuilder();


### PR DESCRIPTION
This adds in support for defining your own custom slot types.

The use case for this: I have a script that automatically takes my generated Skill Builder schema, navigates to the Amazon dev portal, and uploads the new schema file + rebuilds the interaction model. For my skills that have custom slot types, this means uploading a new schema file overwrites my existing custom slot types, which renders that workflow useless. Adding first-class support for custom slot types within the library itself means that the Skill Builder schema file it generates can now contain 100% of your interaction model for skills with custom slot types.

 In its simplest form, you can add a custom slot type via `app.customSlot("SlotName", ["value1", "value2", "value3"])`. There's a slightly more verbose syntax if you want to take advantage of the new Skill Builder features, like synonyms.

If you do that, and then call `app.schemas.skillBuilder()`, the resulting schema object contains your custom slots, ready to paste into the Skill Builder UI.

This doesn't affect intents or actually handling requests (nor should there really be any reason to). It exists purely to thread the data through to the schema JSON.

This would resolve #114 and #222.
