### PR TITLE
Add schema support for ask-cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 4.2.1 (next)
 
+* [#284](https://github.com/alexa-js/alexa-app/pull/284): Add support for generating `ask-cli`-compatible schema JSON - [@lazerwalker](https://github.com/lazerwalker).
 * Your contribution here
+
 
 ### 4.2.0 (September 13, 2017)
 

--- a/README.md
+++ b/README.md
@@ -559,7 +559,7 @@ app.post = function(request, response, type, exception) {
 
 ## Schema and Utterances
 
-The alexa-app module makes it easy to define your intent schema and generate many sample utterances. Optionally pass your schema definition along with your intent handler, and extract the generated content using either the `schemas.intent()` and `utterances()` functions on your app (if using the normal Developer portal) or `schemas.skillBuilder()` if using the new Skill Builder beta.
+The alexa-app module makes it easy to define your intent schema and generate many sample utterances. Optionally pass your schema definition along with your intent handler, and extract the generated content using either the `schemas.intent()` and `utterances()` functions on your app (if using the normal Developer portal), `schemas.skillBuilder()` if using the new Skill Builder beta, or `schemas.askcli()` if using the `ask-cli` tool.
 
 
 ### Schema Syntax
@@ -721,6 +721,48 @@ app.schemas.skillBuilder() =>
       }
     }]
   }];
+}
+```
+
+#### ask-cli Schema
+
+The [ask-cli](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/ask-cli-intro) tool accepts a schema in the same format as the Skill Builder, but is structured slightly differently. The `schemas.askcli()` function generates a JSON string suitable to be used with the `ask deploy` command.
+
+This schema format requires you to specify the invocation name for your skill. You can set this for your skill by setting `app.invocationName`. If you need to use different invocation names for the same skill (e.g. you have both a staging and production version), the schema function itself can take in an invocation name which overwrites the app's default.
+
+```javascript
+app.schemas.askcli("favorite color") =>
+
+{
+  "interactionModel": {
+    "languageModel": {
+      "invocationName": "favorite color"
+      "intents": [{
+        "name": "MyColorIsIntent",
+        "samples": [
+          "my color is {dark brown|Color}",
+          "my color is {green|Color}",
+          "my favorite color is {red|Color}",
+          "my favorite color is {navy blue|Color}"
+        ],
+        "slots": [{
+          "name": "Color",
+          "type": "AMAZON.Color",
+          "samples": []
+        }]
+      }],
+      "types": [{
+        "name": "MyCustomColor",
+        "values": [{
+          "id": null,
+          "name": {
+            "value": "aquamarine",
+            "synonyms": ["aqua", "seafoam", "teal"]
+          }
+        }]
+      }];
+    }
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -698,9 +698,9 @@ alexa.app = function(name) {
       var schema = skillBuilderSchema();
       return JSON.stringify(schema, null, 3);
     },
-    askcli: function() {
+    askcli: function(invocationName) {
       var model = skillBuilderSchema();
-      model.invocationName = self.name;
+      model.invocationName = invocationName || self.invocationName || self.name;
       var schema = {
         interactionModel: {
           languageModel: model

--- a/index.js
+++ b/index.js
@@ -431,7 +431,7 @@ alexa.app = function(name) {
   this.customSlots = {};
   this.customSlot = function(slotName, values) {
     self.customSlots[slotName] = [];
-    
+
     values.forEach(function(value) {
       var valueObj;
       if (typeof value === "string") {
@@ -608,6 +608,67 @@ alexa.app = function(name) {
     });
   };
 
+  var skillBuilderSchema = function() {
+    var schema = {
+      "intents": [],
+      "types": []
+    },
+    intentName, intent, key;
+    for (intentName in self.intents) {
+      intent = self.intents[intentName];
+      var intentSchema = {
+        "name": intent.name,
+        "samples": []
+      };
+      if (intent.utterances && intent.utterances.length > 0) {
+        intent.utterances.forEach(function(sample) {
+          var list = AlexaUtterances(sample,
+            intent.slots,
+            self.dictionary,
+            self.exhaustiveUtterances);
+          list.forEach(function(utterance) {
+            intentSchema.samples.push(utterance);
+          });
+        });
+      }
+      if (intent.slots && Object.keys(intent.slots).length > 0) {
+        intentSchema["slots"] = [];
+        for (key in intent.slots) {
+          //  It's unclear whether `samples` is actually used for slots,
+          // but the interaction model will not build without an (empty) array
+          intentSchema.slots.push({
+            "name": key,
+            "type": intent.slots[key],
+            "samples": []
+          });
+        }
+      }
+      schema.intents.push(intentSchema);
+    }
+
+    for (var slotName in self.customSlots) {
+      var slotSchema = {
+        name: slotName,
+        values: []
+      };
+
+      var values = self.customSlots[slotName];
+      values.forEach(function(value) {
+        var valueSchema = {
+          "id": value.id,
+          "name": {
+            "value": value.value,
+            "synonyms": value.synonyms || []
+          }
+        };
+        slotSchema.values.push(valueSchema);
+      });
+
+      schema.types.push(slotSchema);
+    }
+    return schema;
+  };
+
   this.schemas = {
     intent: function() {
       var schema = {
@@ -634,63 +695,17 @@ alexa.app = function(name) {
     },
 
     skillBuilder: function() {
+      var schema = skillBuilderSchema();
+      return JSON.stringify(schema, null, 3);
+    },
+    askcli: function() {
+      var model = skillBuilderSchema();
+      model.invocationName = self.name;
       var schema = {
-          "intents": [],
-          "types": []
-        },
-        intentName, intent, key;
-      for (intentName in self.intents) {
-        intent = self.intents[intentName];
-        var intentSchema = {
-          "name": intent.name,
-          "samples": []
-        };
-        if (intent.utterances && intent.utterances.length > 0) {
-          intent.utterances.forEach(function(sample) {
-            var list = AlexaUtterances(sample,
-              intent.slots,
-              self.dictionary,
-              self.exhaustiveUtterances);
-            list.forEach(function(utterance) {
-              intentSchema.samples.push(utterance);
-            });
-          });
+        interactionModel: {
+          languageModel: model
         }
-        if (intent.slots && Object.keys(intent.slots).length > 0) {
-          intentSchema["slots"] = [];
-          for (key in intent.slots) {
-            //  It's unclear whether `samples` is actually used for slots,
-            // but the interaction model will not build without an (empty) array
-            intentSchema.slots.push({
-              "name": key,
-              "type": intent.slots[key],
-              "samples": []
-            });
-          }
-        }
-        schema.intents.push(intentSchema);
-      }
-
-      for (var slotName in self.customSlots) {
-        var slotSchema = {
-          name: slotName,
-          values: []
-        };
-
-        var values = self.customSlots[slotName];
-        values.forEach(function(value) {
-          var valueSchema = {
-            "id": value.id,
-            "name": {
-              "value": value.value,
-              "synonyms": value.synonyms || []
-            }
-          }; 
-          slotSchema.values.push(valueSchema);
-        });     
-
-        schema.types.push(slotSchema);
-      }
+      };
       return JSON.stringify(schema, null, 3);
     }
   };

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -449,5 +449,298 @@ describe("Alexa", function() {
         });
       });
     });
+
+    describe("#schemas.askcli", function() {
+      describe("with a minimum intent", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+        });
+
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [{
+                  "name": "AMAZON.PauseIntent",
+                  "samples": []
+                }],
+                "types": []
+              }
+            }
+          });
+        });
+      });
+
+      describe("with empty slots", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent", {
+            "slots": {}
+          });
+        });
+
+        it("contains no slots", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [{
+                  "name": "AMAZON.PauseIntent",
+                  "samples": []
+                }],
+                "types": []
+              }
+            }
+          });
+        });
+      });
+
+      describe("with a slot", function() {
+        beforeEach(function() {
+          testApp.intent("testIntent", {
+            "slots": {
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE"
+            },
+          });
+        });
+
+        it("includes slots", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [{
+                  "name": "testIntent",
+                  "samples": [],
+                  "slots": [{
+                    "name": "Tubular",
+                    "type": "AMAZON.LITERAL",
+                    "samples": []
+                  }, {
+                    "name": "Radical",
+                    "type": "AMAZON.US_STATE",
+                    "samples": []
+                  }]
+                }],
+                "types": []
+              }
+            }
+          });
+        });
+      });
+
+      describe("with simple utterances", function() {
+        beforeEach(function() {
+          testApp.intent("testIntent", {
+            "utterances": ["turn on the thermostat", "kill all humans"]
+          });
+        });
+
+        it("contains utterances", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [{
+                  "name": "testIntent",
+                  "samples": [
+                    "turn on the thermostat",
+                    "kill all humans"
+                  ]
+                }],
+                "types": []
+              }
+            }
+          });
+        });
+      });
+
+      describe("with multiple intents", function() {
+        beforeEach(function() {
+          testApp.intent("AMAZON.PauseIntent");
+
+          testApp.intent("testIntentTwo", {
+            "slots": {
+              "MyCustomSlotType": "CUSTOMTYPE",
+              "Tubular": "AMAZON.LITERAL",
+              "Radical": "AMAZON.US_STATE"
+            },
+          });
+
+          testApp.intent("testIntent", {
+            "slots": {
+              "AirportCode": "FAACODES",
+              "Awesome": "AMAZON.DATE",
+              "Tubular": "AMAZON.LITERAL"
+            },
+          });
+        });
+
+        it("generates the expected schema", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [{
+                  "name": "AMAZON.PauseIntent",
+                  "samples": []
+                }, {
+                  "name": "testIntentTwo",
+                  "samples": [],
+                  "slots": [{
+                    "name": "MyCustomSlotType",
+                    "type": "CUSTOMTYPE",
+                    "samples": []
+                  }, {
+                    "name": "Tubular",
+                    "type": "AMAZON.LITERAL",
+                    "samples": []
+                  }, {
+                    "name": "Radical",
+                    "type": "AMAZON.US_STATE",
+                    "samples": []
+                  }]
+                }, {
+                  "name": "testIntent",
+                  "samples": [],
+                  "slots": [{
+                    "name": "AirportCode",
+                    "type": "FAACODES",
+                    "samples": []
+                  }, {
+                    "name": "Awesome",
+                    "type": "AMAZON.DATE",
+                    "samples": []
+                  }, {
+                    "name": "Tubular",
+                    "type": "AMAZON.LITERAL",
+                    "samples": []
+                  }]
+                }],
+                "types": []
+              }
+            }
+          });
+        });
+      });
+
+      describe("with a custom slot", function() {
+        beforeEach(function() {
+          testApp.customSlot("animal", [
+            "cat",
+            {
+              value: "dog",
+              id: "canine",
+              synonyms: ["doggo", "pupper", "woofmeister"]
+            }
+          ]);
+        });
+
+        it("includes custom slots", function() {
+          var subject = JSON.parse(testApp.schemas.askcli());
+          expect(subject).to.eql({
+            "interactionModel": {
+              "languageModel": {
+                "invocationName": "testApp",
+                "intents": [],
+                "types": [
+                  {
+                    "name": "animal",
+                    "values": [
+                      {
+                        "id": null,
+                        "name": {
+                          "value": "cat",
+                          "synonyms": []
+                        }
+                      },
+                      {
+                        "id": "canine",
+                        "name": {
+                          "value": "dog",
+                          "synonyms": ["doggo", "pupper", "woofmeister"]
+                        }
+                      }
+                    ]
+                  }
+                ]
+              }
+            }
+          });
+        });
+        describe("with multiple custom slots", function() {
+          beforeEach(function() {
+            testApp.customSlot("animal", [
+              "cat",
+              {
+                value: "dog",
+                id: "canine",
+                synonyms: ["doggo", "pupper", "woofmeister"]
+              }
+            ]);
+
+            testApp.customSlot("vegetable", ["carrot", "cucumber"]);
+          });
+
+          it("includes all custom slots", function() {
+            var subject = JSON.parse(testApp.schemas.askcli());
+            expect(subject).to.eql({
+              "interactionModel": {
+                "languageModel": {
+                  "invocationName": "testApp",
+                  "intents": [],
+                  "types": [
+                    {
+                      "name": "animal",
+                      "values": [
+                        {
+                          "id": null,
+                          "name": {
+                            "value": "cat",
+                            "synonyms": []
+                          }
+                        },
+                        {
+                          "id": "canine",
+                          "name": {
+                            "value": "dog",
+                            "synonyms": ["doggo", "pupper", "woofmeister"]
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "name": "vegetable",
+                      "values": [
+                        {
+                          "id": null,
+                          "name": {
+                            "value": "carrot",
+                            "synonyms": []
+                          }
+                        },
+                        {
+                          "id": null,
+                          "name": {
+                            "value": "cucumber",
+                            "synonyms": []
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            });
+          });
+        });
+      });
+    });
   });
 });

--- a/test/test_alexa_app_schema.js
+++ b/test/test_alexa_app_schema.js
@@ -451,6 +451,56 @@ describe("Alexa", function() {
     });
 
     describe("#schemas.askcli", function() {
+      describe("the invocation name", function() {
+        context("when no invocation name is set", function() {
+          it("should use the app name", function() {
+            var subject = JSON.parse(testApp.schemas.askcli());
+            expect(subject).to.eql({
+              "interactionModel": {
+                "languageModel": {
+                  "invocationName": "testApp",
+                  "intents": [],
+                  "types": []
+                }
+              }
+            });
+          })
+        })
+
+        context("when the app's invocationName is set", function() {
+          beforeEach(function() {
+            testApp.invocationName = "my cool skill";
+          })
+
+          it("should use the invocationName", function() {
+            var subject = JSON.parse(testApp.schemas.askcli());
+            expect(subject).to.eql({
+              "interactionModel": {
+                "languageModel": {
+                  "invocationName": "my cool skill",
+                  "intents": [],
+                  "types": []
+                }
+              }
+            });
+          })
+
+          context("when a custom invocation name is passed in", function() {
+            it("should override the app's setting", function() {
+              var subject = JSON.parse(testApp.schemas.askcli("my okay skill"));
+              expect(subject).to.eql({
+                "interactionModel": {
+                  "languageModel": {
+                    "invocationName": "my okay skill",
+                    "intents": [],
+                    "types": []
+                  }
+                }
+              });
+            })
+          })
+        })
+      });
       describe("with a minimum intent", function() {
         beforeEach(function() {
           testApp.intent("AMAZON.PauseIntent");

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -90,6 +90,9 @@ export class app {
 
     /** Generates a schema in the new Skill Builder beta format */
     skillBuilder(): string;
+
+    /** Generates a schema in the modified Skill Builder format accepted by the ask-cli tool */
+    askcli(): string;
   };
 
   /** Generates a list of sample utterances */

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -31,6 +31,7 @@ export class app {
   post: (request: request, response: response, type: string, exception: any) => void;
 
   name: string;
+  invocationName?: string;
   messages: any;
 
   /** By default, alexa-app will persist every request session attribute into
@@ -91,8 +92,12 @@ export class app {
     /** Generates a schema in the new Skill Builder beta format */
     skillBuilder(): string;
 
-    /** Generates a schema in the modified Skill Builder format accepted by the ask-cli tool */
-    askcli(): string;
+    /** Generates a schema in the modified Skill Builder format accepted by the ask-cli tool
+     * @param invocationName {string?} The invocation name to include in the resulting JSON.
+     * If present, invocationName will be used. Otherwise, if app.invocationName is set,
+     * it will be used. Otherwise, it will default to app.name.
+     */
+    askcli(invocationName?: string): string;
   };
 
   /** Generates a list of sample utterances */


### PR DESCRIPTION
Amazon recently released a [CLI](https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/ask-cli-intro) to (among other things) upload changes to your interaction model.

This PR adds a new `app.schemas.askcli` function that can generate JSON in the correct format, such that it will work with `ask deploy` as-is if you write it to disk in the correct folder structure. It's basically the Skill Builder schema, but (a) the top-level wrapping structure is sliiiightly different and (b) it includes the skill's invocation name.

To the latter point: there's now an `app.invocationName` property that can be set, with it falling back to `app.name` if there isn't an invocation name set. The `app.schemas.askcli()` function can also take in an invocation name. I personally have staging and production deployments of the same skill with slightly different invocation names (I assume this is a fairly common use case), so being able to specify that at schema generation time is useful.

I suspect the tooling work I'm doing in my own skill may eventually be able to be abstracted out into a tighter-knit integration, but for now this feels like the right level of adaptation to this library to facilitate working with `ask-cli`.