### PR TITLE
If the user says a custom slot synonym, request.slot() returns the main value instead of the spoken synonym

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 4.2.1 (next)
 
 * [#284](https://github.com/alexa-js/alexa-app/pull/284): Add support for generating `ask-cli`-compatible schema JSON - [@lazerwalker](https://github.com/lazerwalker).
+* [#286](https://github.com/alexa-js/alexa-app/pull/286): When an intent request contains a custom slot value synonym, coerce the slot value into the main value instead of the synonym - [@lazerwalker](https://github.com/lazerwalker).
 * Your contribution here
 
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Skills define handlers for launch, intent, and session end, just like normal Ale
 String request.type()
 
 // return the value passed in for a given slot name
+// if the slot is a custom slot, and the user says a synonym, this will return the main value rather than the synonym
 String request.slot("slotName")
 
 // return the Slot object
@@ -325,6 +326,10 @@ String slot.name
 
 // return the slot's value
 String slot.value
+
+// if the user said a synonym for a custom slot value, `slot.value` returns the main value.
+// slot.rawValue will always contain the actual word the user said
+String slot.rawValue
 
 // return the slot's confirmationStatus
 String slot.confirmationStatus

--- a/index.js
+++ b/index.js
@@ -317,7 +317,15 @@ alexa.intent = function(name, schema, handler) {
 alexa.slot = function(slot) {
   this.name = slot.name;
   this.value = slot.value;
+  this.rawValue = slot.value;
   this.confirmationStatus = slot.confirmationStatus;
+
+  if (slot.resolutions && slot.resolutions.resolutionsPerAuthority && slot.resolutions.resolutionsPerAuthority.length === 1) {
+    var resolution = slot.resolutions.resolutionsPerAuthority[0];
+    if (resolution.values.length === 1) {
+      this.value = resolution.values[0].value.name;
+    }
+  }
 
   this.isConfirmed = function() {
     return 'CONFIRMED' === this.confirmationStatus;

--- a/test/fixtures/intent_request_slot_synonyms.json
+++ b/test/fixtures/intent_request_slot_synonyms.json
@@ -1,0 +1,58 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+    }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "favoriteAnimal",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "animal": {
+          "name": "animal",
+          "value": "doggo",
+          "confirmationStatus": "NONE",
+          "resolutions":{
+            "resolutionsPerAuthority": [{
+              "authority":"amzn1.er-authority.echo-sdk.amzn1.ask.skill.26c2071c-fe9d-44e3-a17a-9d1b2e809ede.Animal",
+              "status": {"code":"ER_SUCCESS_MATCH"},
+              "values": [{
+                "value": {
+                  "name":"dog",
+                  "id":"canine"
+                }
+              }]
+            }]
+          }
+        },
+        "game": {
+          "name": "game",
+          "value": "fetch",
+          "confirmationStatus": "NONE"
+        }
+      }
+    },
+    "dialogState": "STARTED"
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -42,6 +42,28 @@ describe("Alexa", function() {
           });
         });
 
+        context("when there is a custom slot value that's a synonym", function() {
+          var mock = mockHelper.load("intent_request_slot_synonyms.json")
+
+          it("should return the original non-synonym value", function(done) {
+            testApp.intent("favoriteAnimal", function(req, res) {
+              expect(req.slot("animal")).to.equal("dog")
+              expect(req.slots.animal.value).to.equal("dog")
+
+              done()
+            })
+            var request = testApp.request(mock);
+          });
+
+          it("should store the synonym as the rawValue", function(done) {
+            testApp.intent("favoriteAnimal", function(req, res) {
+              expect(req.slots.animal.rawValue).to.equal("doggo")
+              done()
+            })
+            var request = testApp.request(mock);
+          });
+        });
+
         context("with an intent request of airportInfoIntent", function() {
           context("with no intent handler", function() {
             var request = testApp.request(mockRequest);

--- a/types/alexa.d.ts
+++ b/types/alexa.d.ts
@@ -115,7 +115,22 @@ export interface Slot {
   name: string;
   value: string;
   confirmationStatus: "NONE"|"CONFIRMED"|"DENIED";
-  resolutions: any; // TODO
+  resolutions: Resolution;
+}
+
+export interface Resolution {
+  resolutionsPerAuthority: ResolutionPerAuthority[];
+}
+
+export interface ResolutionPerAuthority {
+  authority: string;
+  status: {
+    code: "ER_SUCCESS_MATCH"|"ER_SUCCESS_NO_MATCH"|"ER_ERROR_TIMEOUT"|"ER_ERROR_EXCEPTION";
+  };
+  values: [{
+    name: string;
+    id: string;
+  }];
 }
 
 export interface Stream {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -297,6 +297,7 @@ export class slot {
 
   name: string;
   value: string;
+  rawValue: string;
   confirmationStatus: string;
 
   isConfirmed: () => boolean;


### PR DESCRIPTION
When defining a custom slot, Amazon now allows you to define synonyms for given slot values (something our `app.customSlot` syntax supports).

When a user says a synonym instead of the main custom slot value, the value returned within the intent request (which `alexa-app` in turn picks up for e.g. `request.slot()`) is the synonym rather than the actual value.

To put this in more concrete terms: say you have a custom slot value of "cat" with a synonym of "kitty". If the user says "kitty", the intent will come through as if the user said "kitty" (e.g. `request.slot('pet') == "kitty"`). As a developer, I now manually need to say "okay, I know that 'kitty' isn't in the list of things I was expecting, let's do a lookup of what it's a synonym of". 

It seems more intuitive to me that we'd automatically coerce synonyms into their known main values. This PR makes it so that if the user says "kitty" for a slot called "pet", `request.slot('pet')` (or `request.slots.pet.value`) would return "cat" rather than "kitty". The original "kitty" string is now available at `request.slots.pet.rawValue`.

This is an opinionated change, but it feels more in-line with how I'd intuitively expect "synonyms" to behave in this context.

Thoughts?
