### PR TITLE
Move optionalDependencies to devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#284](https://github.com/alexa-js/alexa-app/pull/284): Add support for generating `ask-cli`-compatible schema JSON - [@lazerwalker](https://github.com/lazerwalker).
 * [#301](https://github.com/alexa-js/alexa-app/pull/301): Updated alexa-verifier-middleware to v1.0.0 - [@tejashah88](https://github.com/tejashah88).
+* [#302](https://github.com/alexa-js/alexa-app/pull/302): Move typescript and dtslint from optionalDependencies to devDependencies - [@lazerwalker](https://github.com/lazerwalker).
 * Your contribution here
 
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "chai-string": "^1.3.0",
     "coveralls": "^2.11.9",
     "danger": "0.6.10",
+    "dtslint": "microsoft/dtslint#production",
     "ejs": "^2.5.5",
     "eslint": "^2.9.0",
     "esprima": "^3.1.3",
@@ -58,10 +59,7 @@
     "mocha": "^2.3.4",
     "sinon": "^1.17.7",
     "sinon-chai": "^2.8.0",
-    "supertest": "^2.0.1"
-  },
-  "optionalDependencies": {
-    "dtslint": "microsoft/dtslint#production",
+    "supertest": "^2.0.1",
     "typescript": "^2.5"
   }
 }


### PR DESCRIPTION
We have typescript and dtslint set up as `optionalDependencies` in `package.json`. This means they get installed when this is pulled in as a client lib, even though people consuming this don't need typescript. This moves them to `devDependencies` instead, which should mean they'll only be installed when someone explicitly clones this repo and runs `npm install` to get a dev setup!

Fixes #300.