### PR TITLE
Feature: Slot Resolutions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#284](https://github.com/alexa-js/alexa-app/pull/284): Add support for generating `ask-cli`-compatible schema JSON - [@lazerwalker](https://github.com/lazerwalker).
 * [#301](https://github.com/alexa-js/alexa-app/pull/301): Updated alexa-verifier-middleware to v1.0.0 - [@tejashah88](https://github.com/tejashah88).
 * [#302](https://github.com/alexa-js/alexa-app/pull/302): Move typescript and dtslint from optionalDependencies to devDependencies - [@lazerwalker](https://github.com/lazerwalker).
-* [#310](https://github.com/alexa-js/alexa-app/pull/310): Feature: Slot Resolutions - [@kobim](https://github.com/kobim)
+* [#310](https://github.com/alexa-js/alexa-app/pull/310): Added support for slot resolutions - [@kobim](https://github.com/kobim).
 * Your contribution here
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#284](https://github.com/alexa-js/alexa-app/pull/284): Add support for generating `ask-cli`-compatible schema JSON - [@lazerwalker](https://github.com/lazerwalker).
 * [#301](https://github.com/alexa-js/alexa-app/pull/301): Updated alexa-verifier-middleware to v1.0.0 - [@tejashah88](https://github.com/tejashah88).
 * [#302](https://github.com/alexa-js/alexa-app/pull/302): Move typescript and dtslint from optionalDependencies to devDependencies - [@lazerwalker](https://github.com/lazerwalker).
+* [#310](https://github.com/alexa-js/alexa-app/pull/310): Feature: Slot Resolutions - [@kobim](https://github.com/kobim)
 * Your contribution here
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@
     * [response](#response)
       * [Building SSML Responses](#building-ssml-responses)
     * [session](#session)
+    * [slot](#slot)
+    * [slotResolution](#slotResolution)
+    * [resolutionValue](#resolutionValue)
 * [Request Handlers](#request-handlers)
     * [LaunchRequest](#launchrequest)
     * [IntentRequest](#intentrequest)
@@ -330,8 +333,38 @@ String slot.value
 // return the slot's confirmationStatus
 String slot.confirmationStatus
 
+// return the slot's resolutions
+SlotResolution[] slot.resolutions
+
 // check if the slot is confirmed
 Boolean slot.isConfirmed()
+
+// return the n-th resolution
+SlotResolution slot.resolution(Integer n)
+```
+
+### slotResolution
+```javascript
+// get the resolution status code
+String resolution.status
+
+// get the list of resolution values
+ResolutionValue resolution.values
+
+// check if the resolution is matched
+Boolean resolution.isMatched()
+
+// Get the first resolution value
+ResolutionValue resolution.first()
+```
+
+### resolutionValue
+```javascript
+// get the value name
+String resolutionValue.name
+
+// get the value id
+String resolutionValue.id
 ```
 
 ## Request Handlers

--- a/index.js
+++ b/index.js
@@ -318,10 +318,40 @@ alexa.slot = function(slot) {
   this.name = slot.name;
   this.value = slot.value;
   this.confirmationStatus = slot.confirmationStatus;
+  if (slot.resolutions && slot.resolutions.resolutionsPerAuthority && slot.resolutions.resolutionsPerAuthority.length > 0) {
+    this.resolutions = slot.resolutions.resolutionsPerAuthority.map(function (resolution) {
+      return new alexa.slotResolution(resolution);
+    });
+  } else {
+    this.resolutions = [];
+  }
 
   this.isConfirmed = function() {
     return 'CONFIRMED' === this.confirmationStatus;
   };
+  this.resolution = function (idx) {
+    idx = idx && idx < this.resolutions.length ? idx : 0;
+    return this.resolutions[idx];
+  };
+};
+
+alexa.slotResolution = function(resolution) {
+  this.status = resolution.status.code;
+  this.values = (resolution.values || []).map(function (elem) {
+    return new alexa.resolutionValue(elem.value);
+  });
+
+  this.isMatched = function() {
+    return 'ER_SUCCESS_MATCH' === this.status;
+  };
+  this.first = function() {
+    return this.values[0];
+  };
+};
+
+alexa.resolutionValue = function (value) {
+  this.name = value.name;
+  this.id = value.id;
 };
 
 alexa.session = function(session) {

--- a/test/fixtures/intent_request_airport_info_resolutions.json
+++ b/test/fixtures/intent_request_airport_info_resolutions.json
@@ -1,0 +1,60 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+    },
+    "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+    "accessToken": null
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "airportInfoIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "AirportCode": {
+          "name": "AirportCode",
+          "value" : "my home airport",
+          "resolutions": {
+            "resolutionsPerAuthority": [
+              {
+                "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.6919844a-733e-4e89-893a-fdcb77e2ef0d.AirportCode",
+                "status": {
+                  "code": "ER_SUCCESS_MATCH"
+                },
+                "values": [
+                  {
+                    "value": {
+                      "name": "JFK",
+                      "id": "200"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/fixtures/intent_request_airport_info_resolutions_not_found.json
+++ b/test/fixtures/intent_request_airport_info_resolutions_not_found.json
@@ -1,0 +1,52 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+    },
+    "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2",
+    "accessToken": null
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "airportInfoIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "AirportCode": {
+          "name": "AirportCode",
+          "value" : "my home airport",
+          "resolutions": {
+            "resolutionsPerAuthority": [
+              {
+                "authority": "amzn1.er-authority.echo-sdk.amzn1.ask.skill.6919844a-733e-4e89-893a-fdcb77e2ef0d.AirportCode",
+                "status": {
+                  "code": "ER_SUCCESS_NO_MATCH"
+                }
+              }
+            ]
+          },
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised);
 var expect = chai.expect;
 chai.config.includeStack = true;
 
-import * as Alexa from '../';
+import * as Alexa from '..';
 
 describe("Alexa", function() {
   describe("app", function() {

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -7,7 +7,7 @@ chai.use(chaiAsPromised);
 var expect = chai.expect;
 chai.config.includeStack = true;
 
-import * as Alexa from '..';
+import * as Alexa from '../';
 
 describe("Alexa", function() {
   describe("app", function() {
@@ -334,6 +334,23 @@ describe("Alexa", function() {
                     type: "SSML"
                   });
                 });
+
+                it("can handle no resolutions", function() {
+                  testApp.intent("airportInfoIntent", {}, function(req, res) {
+                    res.say(req.slots["AirportCode"].resolution() ? "has any" : "empty");
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>empty</speak>",
+                    type: "SSML"
+                  });
+                });
               });
 
               context("when a slot's confirmationStatus is not CONFIRMED", function() {
@@ -353,6 +370,100 @@ describe("Alexa", function() {
 
                   return expect(subject).to.eventually.become({
                     ssml: "<speak>no</speak>",
+                    type: "SSML"
+                  });
+                });
+              });
+
+              context("when a slot has matched resolutions", function() {
+                var mockRequest = mockHelper.load("intent_request_airport_info_resolutions.json");
+
+                it("reports matched resolution", function() {
+                  testApp.intent("airportInfoIntent", {}, function (req, res) {
+                    res.say(req.slots['AirportCode'].resolution().isMatched() ? "yes": "no");
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>yes</speak>",
+                    type: "SSML"
+                  });
+                });
+
+                it("has a name for the resolution value", function() {
+                  testApp.intent("airportInfoIntent", {}, function (req, res) {
+                    res.say(req.slots['AirportCode'].resolution().first().name);
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>JFK</speak>",
+                    type: "SSML"
+                  });
+                });
+
+                it("has an id for the resolution value", function() {
+                  testApp.intent("airportInfoIntent", {}, function (req, res) {
+                    res.say(req.slots['AirportCode'].resolution().first().id);
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>200</speak>",
+                    type: "SSML"
+                  });
+                });
+              });
+
+              context("when a slot has non-matched resolutions", function() {
+                var mockRequest = mockHelper.load("intent_request_airport_info_resolutions_not_found.json");
+
+                it("reports non-matched resolution", function() {
+                  testApp.intent("airportInfoIntent", {}, function (req, res) {
+                    res.say(req.slots['AirportCode'].resolution().isMatched() ? "yes": "no");
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>no</speak>",
+                    type: "SSML"
+                  });
+                });
+
+                it("has no values for the resolution", function() {
+                  testApp.intent("airportInfoIntent", {}, function (req, res) {
+                    var resolution = req.slots['AirportCode'].resolution();
+                    res.say(resolution.first() ? "has value!": "doesn't have any values");
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>doesn't have any values</speak>",
                     type: "SSML"
                   });
                 });

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -101,7 +101,6 @@ describe("Alexa", function() {
 
         testApp.express({
           expressApp: app,
-          router: express.Router(),
           checkCert: false,
           debug: true
         });
@@ -176,7 +175,6 @@ describe("Alexa", function() {
       beforeEach(function() {
         testApp.express({
           expressApp: app,
-          router: express.Router(),
           checkCert: false,
           preRequest: function(json, request, response) {
             fired.preRequest = json;
@@ -202,7 +200,6 @@ describe("Alexa", function() {
       beforeEach(function() {
         testApp.express({
           expressApp: app,
-          router: express.Router(),
           checkCert: true,
           debug: true
         });
@@ -211,7 +208,7 @@ describe("Alexa", function() {
       it("requires a cert header", function() {
         return request(testServer)
           .post('/testApp')
-          .expect(401).then(function(res) {
+          .expect(400).then(function(res) {
             expect(res.body.status).to.equal("failure");
             expect(res.body.reason).to.equal("missing certificate url");
           });
@@ -222,7 +219,7 @@ describe("Alexa", function() {
           .post('/testApp')
           .set('signaturecertchainurl', 'dummy')
           .set('signature', 'dummy')
-          .expect(401).then(function(res) {
+          .expect(400).then(function(res) {
             expect(res.body.status).to.equal("failure");
             expect(res.body.reason).to.equal("missing request (certificate) body");
           });
@@ -236,7 +233,7 @@ describe("Alexa", function() {
           .set('signaturecertchainurl', 'dummy')
           .set('signature', 'dummy')
           .send(mockRequest)
-          .expect(401).then(function(res) {
+          .expect(400).then(function(res) {
             expect(res.body.status).to.equal("failure");
             expect(res.body.reason).to.equal("invalid signature (not base64 encoded)");
           });

--- a/types/alexa.d.ts
+++ b/types/alexa.d.ts
@@ -111,11 +111,32 @@ export interface SessionEndedRequest {
     message: string;
   };
 }
+
+export interface ResolutionValue {
+  value: {
+    name: string;
+    id: string;
+  };
+}
+
+export interface AuthorityResolution {
+  authority: string;
+  status: {
+    code: "ER_SUCCESS_MATCH|ER_SUCCESS_NO_MATCH|ER_ERROR_TIMEOUT|ER_ERROR_EXCEPTION";
+  };
+  values: ResolutionValue[];
+}
+
+export interface Resolutions {
+  type: "Resolutions";
+  resolutionsPerAuthority: AuthorityResolution[];
+}
+
 export interface Slot {
   name: string;
   value: string;
   confirmationStatus: "NONE"|"CONFIRMED"|"DENIED";
-  resolutions: any; // TODO
+  resolutions?: Resolutions;
 }
 
 export interface Stream {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -309,14 +309,37 @@ export class session {
   getAttributes: () => any;
 }
 
+export class resolutionValue {
+  constructor(value: alexa.ResolutionValue);
+
+  value: string;
+  id: string;
+}
+
+export class slotResolution {
+  constructor(resolution: alexa.AuthorityResolution);
+
+  status: string;
+  values: resolutionValue[];
+
+  isMatched: () => boolean;
+  /** Returns the first resolution value */
+  first: () => resolutionValue;
+}
+
 export class slot {
   constructor(slot: alexa.Slot);
 
   name: string;
   value: string;
   confirmationStatus: string;
+  resolutions: slotResolution[];
 
   isConfirmed: () => boolean;
+  /**
+   * Returns the `idx` resolution (if any). If `idx` is omitted, returns the first resolution.
+   */
+  resolution: (idx: number) => slotResolution;
 }
 
 export class dialog {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -312,7 +312,7 @@ export class session {
 export class resolutionValue {
   constructor(value: alexa.ResolutionValue);
 
-  value: string;
+  name: string;
   id: string;
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -339,7 +339,7 @@ export class slot {
   /**
    * Returns the `idx` resolution (if any). If `idx` is omitted, returns the first resolution.
    */
-  resolution: (idx: number) => slotResolution;
+  resolution: (idx?: number) => slotResolution;
 }
 
 export class dialog {


### PR DESCRIPTION
Each slot can allow _resolutions_ for the value, allowing developers to process values like "the biggest airport" which translate to "JFK" (and a possible pre-defined id).

This API allows accessing the slots resolutions (if any), making it easier to define synonyms and custom IDs in the interaction model.

Reference: https://developer.amazon.com/docs/custom-skills/define-synonyms-and-ids-for-slot-type-values-entity-resolution.html
Type definition: https://developer.amazon.com/docs/custom-skills/request-types-reference.html#resolutions-object


** Small note: the express tests were failing due a [recent change in the alexa-verifier-middleware](https://github.com/alexa-js/alexa-verifier-middleware/commit/38ec0c37b15c75ff93cbb650a27c4dda48b62457), hence the change in _test_alexa_integration_express.js_