### PR TITLE
Fix: card tests weren't failing the suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.2.2 (Next)
 
+* [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ alexa.response = function(session) {
       };
     }
 
-    var requiredAttrs = [],
+    var requiredAttrs = ['type'],
       clenseAttrs = [];
 
     switch (oCard.type) {
@@ -85,7 +85,7 @@ alexa.response = function(session) {
     }
 
     var hasAllReq = requiredAttrs.every(function(idx) {
-      if (!(idx in oCard)) {
+      if (!(idx in oCard) || typeof oCard[idx] === 'undefined') {
         console.error('Card object is missing required attr "' + idx + '"');
         return false;
       }

--- a/test/test_alexa_app_cards.js
+++ b/test/test_alexa_app_cards.js
@@ -67,7 +67,7 @@ describe("Alexa", function() {
                 var cardResponse = subject.then(function(response) {
                   return response.response.card;
                 });
-                return expect(cardResponse).to.eventually.become({});
+                return expect(cardResponse).to.eventually.be.undefined;
               });
             });
           });

--- a/test/test_alexa_app_cards.js
+++ b/test/test_alexa_app_cards.js
@@ -53,7 +53,7 @@ describe("Alexa", function() {
                 var cardResponse = subject.then(function(response) {
                   return response.response;
                 });
-                expect(cardResponse).to.eventually.not.have.property("card");
+                return expect(cardResponse).to.eventually.not.have.property("card");
               });
             });
 
@@ -67,7 +67,7 @@ describe("Alexa", function() {
                 var cardResponse = subject.then(function(response) {
                   return response.response.card;
                 });
-                expect(cardResponse).to.eventually.become({});
+                return expect(cardResponse).to.eventually.become({});
               });
             });
           });


### PR DESCRIPTION
Tests were completing successfully although 1 case were failing because `eventually` assertions should be returned in the test case:
<img width="1121" alt="screen shot 2018-02-19 at 10 49 50" src="https://user-images.githubusercontent.com/679761/36369096-adbe0b72-1562-11e8-9196-9d0380b79b92.png">
(committing the fix to the test first, to make sure the fix works and tests fail.)

As for the fix itself, the [Card object](https://developer.amazon.com/docs/custom-skills/request-and-response-json-reference.html#card-object) states the `type` is required, hence my change added it as a required field.