### PR TITLE
Example which creates output for use with new Skill Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * [#314](https://github.com/alexa-js/alexa-app/pull/314): Fix handling of `undefined` slot values - [@User1m](https://github.com/user1m).
-* [#319](https://github.com/alexa-js/alexa-app/pull/319): Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2)
+* Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2)
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * [#314](https://github.com/alexa-js/alexa-app/pull/314): Fix handling of `undefined` slot values - [@User1m](https://github.com/user1m).
-* [#322](https://github.com/alexa-js/alexa-app/pull/322)Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2).
+* [#322](https://github.com/alexa-js/alexa-app/pull/322): Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2).
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * [#314](https://github.com/alexa-js/alexa-app/pull/314): Fix handling of `undefined` slot values - [@User1m](https://github.com/user1m).
+* [#319](https://github.com/alexa-js/alexa-app/pull/319): Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2)
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 * [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * [#314](https://github.com/alexa-js/alexa-app/pull/314): Fix handling of `undefined` slot values - [@User1m](https://github.com/user1m).
-* Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2)
+* [#322](https://github.com/alexa-js/alexa-app/pull/322)Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2).
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/example/views/test.ejs
+++ b/example/views/test.ejs
@@ -1,4 +1,8 @@
 <div style="white-space:pre;border:1px solid black;margin:5px;padding:5px;font-family:monospace;">
+Skill Builder:
+
+<%=app.schemas.skillBuilder()%>
+
 Schema:
 
 <%=schema%>


### PR DESCRIPTION
Putting <%=app.schemas.skillBuilder()%> in an ejs file seems to create the output which can be used with the new Skill Builder.

(Sorry, I'm not super familiar with using GitHub, hopefully this PR is in the right format to be useful.)