### PR TITLE
Run dtslint only on the latest node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ node_js:
   - 5
   - 6
   - 7
+  - 8
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
         - npm run-script danger
         - npm run-script lint
         - npm run-script test-with-coverage
-        - npm install dtslint
+        - npm install dtslint@^0.2
         - npm run dtslint
       after_script:
         - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#315](https://github.com/alexa-js/alexa-app/pull/315): Fix card tests and required card type - [@kobim](https://github.com/kobim).
 * [#314](https://github.com/alexa-js/alexa-app/pull/314): Fix handling of `undefined` slot values - [@User1m](https://github.com/user1m).
 * [#322](https://github.com/alexa-js/alexa-app/pull/322): Included Skill Builder example in example.ejs - [@funkydan2](https://github.com/funkydan2).
+* [#329](https://github.com/alexa-js/alexa-app/pull/329): Run dtslint only on the latest node version - [@kobim](https://github.com/kobim).
 * Your contribution here.
 
 ### 4.2.1 (February 1, 2018)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "chai-string": "^1.3.0",
     "coveralls": "^2.11.9",
     "danger": "0.6.10",
-    "dtslint": "^0.2",
     "ejs": "^2.5.5",
     "eslint": "^2.9.0",
     "esprima": "^3.1.3",


### PR DESCRIPTION
As dtslint is only required for linting the definition files, and its minimum requirements are `node>=6.0.0` (as of _dtslint@0.2_), there's no need to try and install it for older node versions.

(See issues at alexa-js/alexa-app#324 and palantir/tslint#3792)

# Other options which were rejected
1. Rolling dtslint to v0.1.2 where tslint version is 5.0.0 and maximum TypeScript version is 2.3 (instaed of _next_)
The `npm install` phase passes, but we can't run `npm run dtslint` as it uses arrow functions (which were only introduced at node v4)