### PR TITLE
Add coveralls as a check for pull requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ matrix:
         - npm run-script test-with-coverage
         - npm install dtslint@^0.2
         - npm run dtslint
-      after_script:
-        - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 node_js:
   - 1
@@ -30,6 +28,9 @@ cache:
 
 before_install:
   - npm config set spin false
+
+after_success:
+  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 4.2.3 (Next)
 
+* [#344](https://github.com/alexa-js/alexa-app/pull/344): Making coveralls comment on pull requests - [@kobim](https://github.com/kobim).
 * Your contribution here.
 
 ### 4.2.2 (April 7, 2018)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 4.2.3 (Next)
 
-* [#344](https://github.com/alexa-js/alexa-app/pull/344): Making coveralls comment on pull requests - [@kobim](https://github.com/kobim).
+* [#344](https://github.com/alexa-js/alexa-app/pull/344): Add coveralls as a check for pull requests - [@kobim](https://github.com/kobim).
 * Your contribution here.
 
 ### 4.2.2 (April 7, 2018)

--- a/index.js
+++ b/index.js
@@ -334,7 +334,7 @@ alexa.slot = function(slot) {
     return 'CONFIRMED' === this.confirmationStatus;
   };
   this.resolution = function(idx) {
-    idx = idx && idx < this.resolutions.length ? idx : 0;
+    idx = ( typeof idx === 'number' && idx >= 0 && idx < this.resolutions.length ) ? idx : 0;
     return this.resolutions[idx];
   };
 };

--- a/index.js
+++ b/index.js
@@ -699,7 +699,7 @@ alexa.app = function(name) {
           "id": value.id,
           "name": {
             "value": value.value,
-            "synonyms": value.synonyms || []
+            "synonyms": value.synonyms
           }
         };
         slotSchema.values.push(valueSchema);

--- a/test/fixtures/intent_request_food_delivery_dialog_undefined.json
+++ b/test/fixtures/intent_request_food_delivery_dialog_undefined.json
@@ -1,0 +1,40 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "attributes": {},
+    "user": {
+      "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+    }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "deliveryCreationRequest",
+      "confirmationStatus": "CONFIRMED",
+      "slots": {
+        "genre": {
+          "name": "genre",
+          "value": "chinese",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/fixtures/intent_request_malformed_session.json
+++ b/test/fixtures/intent_request_malformed_session.json
@@ -1,0 +1,39 @@
+{
+  "version": "1.0",
+  "session": {
+    "new": false,
+    "sessionId": "amzn1.echo-api.session.abeee1a7-aee0-41e6-8192-e6faaed9f5ef",
+    "application": {
+      "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+    },
+    "user": {
+      "userId": null
+    }
+  },
+  "request": {
+    "type": "IntentRequest",
+    "requestId": "amzn1.echo-api.request.6919844a-733e-4e89-893a-fdcb77e2ef0d",
+    "timestamp": "2015-05-13T12:34:56Z",
+    "intent": {
+      "name": "airportInfoIntent",
+      "confirmationStatus": "NONE",
+      "slots": {
+        "AirportCode": {
+          "name": "AirportCode",
+          "value": "JFK",
+          "confirmationStatus": "NONE"
+        }
+      }
+    }
+  },
+  "context": {
+    "System": {
+      "user": {
+        "userId": "amzn1.account.AM3B227HF3FAM1B261HK7FFM3A2"
+      },
+      "application": {
+        "applicationId": "amzn1.echo-sdk-ams.app.000000-d0ed-0000-ad00-000000d00ebe"
+      }
+    }
+  }
+}

--- a/test/test_alexa_app_dialog.js
+++ b/test/test_alexa_app_dialog.js
@@ -73,6 +73,22 @@ describe("Alexa", function() {
 
           context("when an intent's dialogState is not STARTED", function() {
             beforeEach(function() {
+              setupHandlerAndSubject(undefined, function(req, res) {
+                res.say(req.getDialog().isStarted() ? "yes" : "no");
+                return true;
+              });
+            });
+
+            it("reports dialogState is not STARTED", function() {
+              return expect(subject).to.eventually.become({
+                ssml: "<speak>no</speak>",
+                type: "SSML"
+              });
+            });
+          });
+
+          context("when an intent's dialogState is undefined", function() {
+            beforeEach(function() {
               setupHandlerAndSubject("completed", function(req, res) {
                 res.say(req.getDialog().isStarted() ? "yes" : "no");
                 return true;

--- a/test/test_alexa_app_initialization.js
+++ b/test/test_alexa_app_initialization.js
@@ -39,15 +39,16 @@ describe("Alexa", function() {
   });
 
   describe("app without a name", function() {
+    const CleanAlexaApp = require('../');
     var testApp;
 
     beforeEach(function() {
-      Alexa.apps = [];
-      testApp = new Alexa.app();
+      CleanAlexaApp.apps = {};
+      testApp = new CleanAlexaApp.app();
     })
 
     it("doesn't add the app to alexa.apps", function() {
-      return expect(Object.keys(Alexa.apps).length).to.eq(0);
+      return expect(Object.keys(CleanAlexaApp.apps).length).to.eq(0);
     });
   });
 });

--- a/test/test_alexa_app_initialization.js
+++ b/test/test_alexa_app_initialization.js
@@ -37,4 +37,17 @@ describe("Alexa", function() {
       });
     });
   });
+
+  describe("app without a name", function() {
+    var testApp;
+
+    beforeEach(function() {
+      Alexa.apps = [];
+      testApp = new Alexa.app();
+    })
+
+    it("doesn't add the app to alexa.apps", function() {
+      return expect(Object.keys(Alexa.apps).length).to.eq(0);
+    });
+  });
 });

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -68,6 +68,7 @@ describe("Alexa", function() {
             var expectedMessage = "tubular!";
 
             beforeEach(function() {
+              testApp.pre = undefined;
               testApp.intent("airportInfoIntent", {}, function(req, res) {
                 res.say(expectedMessage);
                 return true;

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -414,7 +414,24 @@ describe("Alexa", function() {
 
                 it("has an id for the resolution value", function() {
                   testApp.intent("airportInfoIntent", {}, function(req, res) {
-                    res.say(req.slots['AirportCode'].resolution().first().id);
+                    res.say(req.slots['AirportCode'].resolution(0).first().id);
+                    return true;
+                  });
+
+                  var request = testApp.request(mockRequest);
+                  var subject = request.then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>200</speak>",
+                    type: "SSML"
+                  });
+                });
+
+                it("fallbacks to first resolution if index doesn't exist", function() {
+                  testApp.intent("airportInfoIntent", {}, function(req, res) {
+                    res.say(req.slots['AirportCode'].resolution(200).first().id);
                     return true;
                   });
 

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -134,6 +134,35 @@ describe("Alexa", function() {
                     type: "SSML"
                   });
                 });
+
+                it("allows pre function to resolve wihout going through the intent handler", function() {
+                  var preMessage = "resolved!!";
+
+                  /**
+                   * @param {Alexa.request} req
+                   * @param {Alexa.response} res
+                   * @param {string} type
+                   */
+                  testApp.pre = function(req, res, type) {
+                    res.say(preMessage);
+                    res.resolved = true;
+                  };
+
+                  testApp.intent("airportInfoIntent", {},
+                    function(req, res) {
+                      res.say("foobar");
+                      return true;
+                    });
+
+                  var subject = testApp.request(mockRequest).then(function(response) {
+                    return response.response.outputSpeech;
+                  });
+
+                  return expect(subject).to.eventually.become({
+                    ssml: "<speak>" + preMessage + "</speak>",
+                    type: "SSML"
+                  });
+                })
               });
 
               it("clears output when clear is called", function() {

--- a/test/test_alexa_app_intent_request.js
+++ b/test/test_alexa_app_intent_request.js
@@ -69,6 +69,7 @@ describe("Alexa", function() {
 
             beforeEach(function() {
               testApp.pre = undefined;
+              testApp.post = undefined;
               testApp.intent("airportInfoIntent", {}, function(req, res) {
                 res.say(expectedMessage);
                 return true;
@@ -540,8 +541,7 @@ describe("Alexa", function() {
                       return res.fail("whoops");
                     });
 
-                  var subject = testApp.request(mockRequest);
-                  return expect(subject).to.be.rejectedWith("whoops");
+                  return testApp.request(mockRequest).should.be.rejectedWith("whoops");
                 });
 
                 it("can clear failure in post", function() {

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -550,5 +550,27 @@ describe("Alexa", function() {
         });
       });
     });
+
+    describe("intent request with malformed session", function() {
+      var mockRequest = mockHelper.load("intent_request_malformed_session.json");
+
+      it("responds a valid session object", function() {
+        testApp.pre = function(req, res, type) {
+          if (req.hasSession()) {
+            req.getSession().set("foo", "bar");
+          }
+        };
+
+        var subject = testApp.request(mockRequest).then(function(response) {
+          return response.sessionAttributes;
+        });
+
+        return Promise.all([
+          expect(subject).to.eventually.become({
+            "foo": "bar"
+          })
+        ]);
+      });
+    });
   });
 });

--- a/test/test_alexa_app_session.js
+++ b/test/test_alexa_app_session.js
@@ -219,6 +219,27 @@ describe("Alexa", function() {
           ]);
         });
       });
+
+      context("intent handler without shouldEndSession", function() {
+        it("responds without shouldEndSession", function() {
+          testApp.intent("airportInfoIntent", {}, function(req, res) {
+            res.say("hi").shouldEndSession();
+            res.session("foo", true);
+            res.session("bar", {
+              qaz: "woah"
+            });
+            res.clearSession();
+            return true;
+          });
+
+          var subject = testApp.request(mockRequest).then(function(response) {
+            return response.sessionAttributes;
+          });
+          return Promise.all([
+            expect(subject).to.eventually.become({})
+          ]);
+        });
+      });
     });
 
     describe("#response", function() {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -162,6 +162,15 @@ describe("Alexa", function() {
               expect(response.text).to.eq(testApp.schemas.skillBuilder());
             });
         });
+
+        it("returns empty schema for invalid schema type", function() {
+          return request(testServer)
+            .get('/testApp?schema&schemaType=invalid')
+            .expect(200).then(function(response) {
+              expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+              expect(response.text).to.eq('');
+            });
+        });
       })
 
       it("returns debug utterances", function() {

--- a/test/test_alexa_integration_express.js
+++ b/test/test_alexa_integration_express.js
@@ -183,6 +183,27 @@ describe("Alexa", function() {
       });
     });
 
+    context("#express with debug set to true and has empty intents", function() {
+      beforeEach(function() {
+        testApp.intent("emptyIntent");
+
+        testApp.express({
+          expressApp: app,
+          checkCert: false,
+          debug: true
+        });
+      });
+
+      it("returns no utterances", function() {
+        return request(testServer)
+          .get('/testApp?utterances')
+          .expect(200).then(function(response) {
+            expect(response.headers['content-type']).to.equal('text/plain; charset=utf-8');
+            expect(response.text).to.eq('');
+          });
+      });
+    });
+
     context("#express with debug set to false", function() {
       beforeEach(function() {
         var router = express.Router();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -235,7 +235,7 @@ export class response {
    * Tells Alexa whether the user's session is over; sessions end by default.
    * You can optionally pass a reprompt message.
    */
-  shouldEndSession: (end: boolean, reprompt?: string) => response;
+  shouldEndSession: (end?: boolean, reprompt?: string) => response;
 
   /**
    * Sends the response to the Alexa device (success) immediately.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ export type ErrorHandler = (e: any, request: request, response: response) => voi
 export let apps: {[name: string]: app};
 
 export class app {
-  constructor(name: string);
+  constructor(name?: string);
 
   /**
    * Executed before any event handlers. This is useful to setup new sessions,


### PR DESCRIPTION
Following #330, I added coveralls as a status check on pull requests, so we will be able to understand if coverage increased/decreased before we merge (and act accordingly).

In the process, I added/fixed tests to make sure all the branches of the code will get called - reached to 100% coverage across all parameters.