### PR TITLE
Issue #359 .reprompt() not concatenating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [#344](https://github.com/alexa-js/alexa-app/pull/344): Add coveralls as a check for pull requests - [@kobim](https://github.com/kobim).
 * [#352](https://github.com/alexa-js/alexa-app/pull/352): Allow utterance expansion in custom slot type synonyms - [@daanzu](https://github.com/daanzu).
 * [#361](https://github.com/alexa-js/alexa-app/pull/361): Fix object reference for dialogState in in doc - [@Sephtenen](https://github.com/Sephtenen).
-* Your contribution here.
+* [#364](https://github.com/alexa-js/alexa-app/pull/364): Fix reprompt() to concatenate multiple SSML prompts - [@andrewjhunt](https://github.com/andrewjhunt).
 
 ### 4.2.2 (April 7, 2018)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * [#352](https://github.com/alexa-js/alexa-app/pull/352): Allow utterance expansion in custom slot type synonyms - [@daanzu](https://github.com/daanzu).
 * [#361](https://github.com/alexa-js/alexa-app/pull/361): Fix object reference for dialogState in in doc - [@Sephtenen](https://github.com/Sephtenen).
 * [#364](https://github.com/alexa-js/alexa-app/pull/364): Fix reprompt() to concatenate multiple SSML prompts - [@andrewjhunt](https://github.com/andrewjhunt).
+* Your contribution here.
 
 ### 4.2.2 (April 7, 2018)
 

--- a/README.md
+++ b/README.md
@@ -297,6 +297,13 @@ var speechOutput = speech.ssml();
 response.say(speechOutput);
 ```
 
+Example using multiple reprompts. The reprompts are spoken to the user if they do not respond to the main prompt or say something that does not map to a defined intent:
+```javascript
+response.say('What is your request?')
+  .reprompt('Sorry, I didn\'t catch that.')
+  .reprompt('What is your request?');
+```
+
 ### session
 ```javascript
 // check if you can use session (read or write)

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ alexa.response = function(session) {
       };
     } else {
       // append str to the current outputSpeech, stripping the out speak tag
-      this.response.response.reprompt.outputSpeech.ssml = SSML.fromStr(str, this.response.response.reprompt.outputSpeech.text);
+      this.response.response.reprompt.outputSpeech.ssml = SSML.fromStr(str, this.response.response.reprompt.outputSpeech.ssml);
     }
     return this;
   };

--- a/test/test_alexa_app_display_element_selected_request.js
+++ b/test/test_alexa_app_display_element_selected_request.js
@@ -69,7 +69,7 @@ describe("Alexa", function() {
                 });
 
                 return expect(subject).to.eventually.become({
-                  ssml: "<speak>" + expectedReprompt + "</speak>",
+                  ssml: "<speak>" + expectedReprompt + " " + expectedReprompt + "</speak>",
                   type: "SSML"
                 });
               });

--- a/test/test_alexa_app_launch_request.js
+++ b/test/test_alexa_app_launch_request.js
@@ -69,7 +69,7 @@ describe("Alexa", function() {
                 });
 
                 return expect(subject).to.eventually.become({
-                  ssml: "<speak>" + expectedReprompt + "</speak>",
+                  ssml: "<speak>" + expectedReprompt + " " + expectedReprompt + "</speak>",
                   type: "SSML"
                 });
               });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -199,7 +199,10 @@ export class response {
   /** Empties the response text */
   clear: () => response;
 
-  /** Tells Alexa to re-prompt the user for a response, if it didn't hear anything valid */
+  /**
+   * Tells Alexa to re-prompt the user for a response, if it didn't hear anything valid.
+   * Multiple calls to say() will be appended to each other.
+   */
   reprompt: (phrase: string) => response;
 
   /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -201,7 +201,7 @@ export class response {
 
   /**
    * Tells Alexa to re-prompt the user for a response, if it didn't hear anything valid.
-   * Multiple calls to say() will be appended to each other.
+   * Multiple calls to reprompt() will be appended to each other.
    */
   reprompt: (phrase: string) => response;
 


### PR DESCRIPTION
Fixes #359 
https://github.com/alexa-js/alexa-app/blob/master/index.js#L51

Example: the following will speak "1 2" as output.
  response.reprompt("1").reprompt("2")

Existing unit tests are updated and pass.

NOTE: the doc is not explicit on the expected behavior of multiple reprompts for the same response. I expected that multiple reprompt() would also concatenate as say(). The existing unit tests didn't reflect this but it's not clear that was intentional. Plus the code appeared to reference a non-defined variable.