### PR TITLE
Fix node < 5 tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "alexa-app",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-preset-es2015": "^6.24.1",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.3.0",
-    "chai-string": "^1.3.0",
+    "chai-string": "1.4.0",
     "coveralls": "^2.11.9",
     "danger": "0.6.10",
     "ejs": "^2.5.5",


### PR DESCRIPTION
_chai-string_ version 1.5.0 [updated _chai_ dependency to > 4](https://github.com/onechiporenko/chai-string/commit/8fc233c38dedf1f8f733cd290670d7d14dbed3e1#diff-b9cfc7f2cdf78a7f4b91a753d10865a2), hence breaking our devDependencies tree.

Pinning to version 1.4.0 (which was already locked in _package-lock.json_) would resolve this issue (until we will upgrade _chai_ and its dependencies).