### PR TITLE
Travis CI to include node v10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ node_js:
   - 7
   - 8
   - 9
+  - 10
 
 cache:
   directories:


### PR DESCRIPTION
Node v11 just released, so let's add v10 to the test matrix.